### PR TITLE
Correct travis builds for examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
   - PROJECT_DIR=todo-mvc
   - PROJECT_DIR=monster-cards
+  - PROJECT_DIR=dojo-cli-example
   global:
   - SAUCE_USERNAME: dojo2-ts-ci
   - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
@@ -18,7 +19,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:saucelabs
+- grunt ci
 notifications:
   slack:
     on_success: change

--- a/dojo-cli-example/Gruntfile.js
+++ b/dojo-cli-example/Gruntfile.js
@@ -2,4 +2,8 @@ module.exports = function (grunt) {
 	require('grunt-dojo2').initConfig(grunt, {
 		/* any custom configuration goes here */
 	});
+
+	grunt.registerTask('ci', [
+		'intern:node'
+	]);
 };

--- a/monster-cards/Gruntfile.js
+++ b/monster-cards/Gruntfile.js
@@ -14,4 +14,8 @@ module.exports = function (grunt) {
 	});
 
 	grunt.registerTask('dev', grunt.config.get('devTasks').concat(['copy:staticFiles']));
+
+	grunt.registerTask('ci', [
+		'intern:saucelabs'
+	]);
 };

--- a/todo-mvc/Gruntfile.js
+++ b/todo-mvc/Gruntfile.js
@@ -29,4 +29,8 @@ module.exports = function (grunt) {
 		'copy:staticFiles'
 	]);
 
+	grunt.registerTask('ci', [
+		'intern:saucelabs'
+	]);
+
 };


### PR DESCRIPTION
- travis now calls `grunt ci`
- implemented `grunt ci` for each example