### PR TITLE
todo-mvc refactor for nodeAttribute feature and compose feature

### DIFF
--- a/todo-mvc/src/index.ts
+++ b/todo-mvc/src/index.ts
@@ -1,4 +1,4 @@
-(<DojoLoader.RootRequire> require).config({
+require.config({
 	baseUrl: '../../',
 	packages: [
 		{ name: 'src', location: '_build/src' },

--- a/todo-mvc/src/widgets/createCheckboxInput.ts
+++ b/todo-mvc/src/widgets/createCheckboxInput.ts
@@ -8,7 +8,7 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export interface CheckboxInputOptions extends WidgetOptions<FormFieldMixinState<string>>, FormFieldMixinOptions<string, FormFieldMixinState<string>> { }
+export type CheckboxInputOptions = WidgetOptions<FormFieldMixinState<string>> & FormFieldMixinOptions<string, FormFieldMixinState<string>>;
 
 export type CheckboxInput = Widget<FormFieldMixinState<string>> & FormFieldMixin<string, FormFieldMixinState<string>>;
 

--- a/todo-mvc/src/widgets/createCheckboxInput.ts
+++ b/todo-mvc/src/widgets/createCheckboxInput.ts
@@ -1,4 +1,3 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
 import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
@@ -10,16 +9,14 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 }
 
 export type CheckboxInputState = RenderMixinState & FormFieldMixinState<string> & {
-	checked?: boolean
+	checked?: boolean;
 };
 
 export type CheckboxInputOptions = RenderMixinOptions<CheckboxInputState> & FormFieldMixinOptions<string, CheckboxInputState>;
 
 export type CheckboxInput = RenderMixin<CheckboxInputState> & FormFieldMixin<string, CheckboxInputState> & VNodeEvented;
 
-export interface CheckboxInputFactory extends ComposeFactory<CheckboxInput, CheckboxInputOptions> { }
-
-const createCheckboxInput: CheckboxInputFactory = createRenderMixin
+const createCheckboxInput = createRenderMixin
 	.mixin(createFormFieldMixin)
 	.mixin({
 		mixin: createVNodeEvented,
@@ -31,18 +28,15 @@ const createCheckboxInput: CheckboxInputFactory = createRenderMixin
 	})
 	.extend({
 		nodeAttributes: [
-			function (this: CheckboxInput) {
-				const props: VNodeProperties = {};
-
-				if (this.state.checked !== undefined) {
-					props.checked = this.state.checked;
-				}
-
-				return props;
+			function (this: CheckboxInput): VNodeProperties {
+				const { checked } = this.state;
+				return checked !== undefined ? { checked } : {};
 			}
 		],
-		type: 'checkbox',
-		tagName: 'input'
+
+		tagName: 'input',
+
+		type: 'checkbox'
 	});
 
 export default createCheckboxInput;

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -1,4 +1,3 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import WeakMap from 'dojo-shim/WeakMap';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
 import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
@@ -19,8 +18,6 @@ export type FocusableTextInputOptions = RenderMixinOptions<FocusableTextInputSta
 
 export type FocusableTextInput = RenderMixin<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState> & VNodeEvented;
 
-export type FocusableTextInputFactory = ComposeFactory<FocusableTextInput, FocusableTextInputOptions>;
-
 const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInputElement): void}>();
 
 function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
@@ -33,7 +30,7 @@ function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	}
 }
 
-const createFocusableTextInput: FocusableTextInputFactory = createRenderMixin
+const createFocusableTextInput = createRenderMixin
 	.mixin(createFormFieldMixin)
 	.mixin({
 		mixin: createVNodeEvented,
@@ -58,8 +55,10 @@ const createFocusableTextInput: FocusableTextInputFactory = createRenderMixin
 				return props;
 			}
 		],
-		type: 'text',
-		tagName: 'input'
+
+		tagName: 'input',
+
+		type: 'text'
 	});
 
 export default createFocusableTextInput;

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -10,7 +10,7 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export interface FocusableTextInputOptions extends WidgetOptions<FormFieldMixinState<string>>, FormFieldMixinOptions<string, FormFieldMixinState<string>> { }
+export type FocusableTextInputOptions = WidgetOptions<FormFieldMixinState<string>> & FormFieldMixinOptions<string, FormFieldMixinState<string>>;
 
 export type FocusableTextInput = Widget<FormFieldMixinState<string>> & FormFieldMixin<string, FormFieldMixinState<string>> & {state: any};
 

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -1,8 +1,8 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import WeakMap from 'dojo-shim/WeakMap';
-import createTextInput from 'dojo-widgets/createTextInput';
-import { Widget, WidgetOptions } from 'dojo-widgets/createWidget';
-import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from 'dojo-widgets/mixins/createFormFieldMixin';
+import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
+import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'maquette';
 
 /* I suspect this needs to go somewhere else */
@@ -10,11 +10,16 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export type FocusableTextInputOptions = WidgetOptions<FormFieldMixinState<string>> & FormFieldMixinOptions<string, FormFieldMixinState<string>>;
+export type FocusableTextInputState = RenderMixinState & FormFieldMixinState<string> & {
+	focused?: boolean;
+	placeholder?: string;
+};
 
-export type FocusableTextInput = Widget<FormFieldMixinState<string>> & FormFieldMixin<string, FormFieldMixinState<string>> & {state: any};
+export type FocusableTextInputOptions = RenderMixinOptions<FocusableTextInputState> & FormFieldMixinOptions<string, FocusableTextInputState>;
 
-export interface FocusableTextInputFactory extends ComposeFactory<FocusableTextInput, FocusableTextInputOptions> { }
+export type FocusableTextInput = RenderMixin<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState> & VNodeEvented;
+
+export type FocusableTextInputFactory = ComposeFactory<FocusableTextInput, FocusableTextInputOptions>;
 
 const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInputElement): void}>();
 
@@ -28,24 +33,10 @@ function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	}
 }
 
-const createFocusableTextInput: FocusableTextInputFactory = createTextInput
+const createFocusableTextInput: FocusableTextInputFactory = createRenderMixin
+	.mixin(createFormFieldMixin)
 	.mixin({
-		mixin: createFormFieldMixin,
-		aspectAdvice: {
-			before: {
-				getNodeAttributes(overrides: VNodeProperties = {}) {
-					const focusableTextInput: FocusableTextInput = this;
-
-					overrides.afterUpdate = afterUpdateFunctions.get(focusableTextInput);
-
-					if (focusableTextInput.state.placeholder !== undefined) {
-						overrides.placeholder = focusableTextInput.state.placeholder;
-					}
-
-					return [overrides];
-				}
-			}
-		},
+		mixin: createVNodeEvented,
 		initialize(instance) {
 			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
 				instance.value = event.target.value;
@@ -54,6 +45,19 @@ const createFocusableTextInput: FocusableTextInputFactory = createTextInput
 		}
 	})
 	.extend({
+		nodeAttributes: [
+			function (this: FocusableTextInput) {
+				const props: VNodeProperties = {
+					afterUpdate: afterUpdateFunctions.get(this)
+				};
+
+				if (this.state.placeholder) {
+					props.placeholder = this.state.placeholder;
+				}
+
+				return props;
+			}
+		],
 		type: 'text',
 		tagName: 'input'
 	});

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -1,54 +1,50 @@
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
+import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
 import { h, VNode } from 'maquette';
 
-interface TodoFilterState extends WidgetState {
+type TodoFilterState = RenderMixinState & {
 	activeFilter?: string;
-}
+};
 
-type TodoFilterOptions = WidgetOptions<TodoFilterState>;
+type TodoFilterOptions = RenderMixinOptions<TodoFilterState>;
 
-type TodoFilter = Widget<TodoFilterState>;
+type TodoFilter = RenderMixin<TodoFilterState>;
 
-const createTodoFilter = createWidget
-	.mixin({
-		mixin: {
-			getChildrenNodes(): VNode[] {
-				const todoFilter: TodoFilter = this;
-				const filter = todoFilter.state.activeFilter;
-				return [
-					h('li', {}, [
-						h('a', {
-							innerHTML: 'All',
-							href: '#all',
-							classes: {
-								selected: filter === 'all'
-							}
-						})
-					]),
-					h('li', {}, [
-						h('a', {
-							innerHTML: 'Active',
-							href: '#active',
-							classes: {
-								selected: filter === 'active'
-							}
-						})
-					]),
-					h('li', {}, [
-						h('a', {
-							innerHTML: 'Completed',
-							href: '#completed',
-							classes: {
-								selected: filter === 'completed'
-							}
-						})
-					])
-				];
-			}
-		}
-	})
+const createTodoFilter = createRenderMixin
 	.extend({
-		'tagName': 'ul'
+		getChildrenNodes(this: TodoFilter): VNode[] {
+			const { activeFilter } = this.state;
+			return [
+				h('li', {}, [
+					h('a', {
+						innerHTML: 'All',
+						href: '#all',
+						classes: {
+							selected: activeFilter === 'all'
+						}
+					})
+				]),
+				h('li', {}, [
+					h('a', {
+						innerHTML: 'Active',
+						href: '#active',
+						classes: {
+							selected: activeFilter === 'active'
+						}
+					})
+				]),
+				h('li', {}, [
+					h('a', {
+						innerHTML: 'Completed',
+						href: '#completed',
+						classes: {
+							selected: activeFilter === 'completed'
+						}
+					})
+				])
+			];
+		},
+
+		tagName: 'ul'
 	});
 
 export default createTodoFilter;

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -5,7 +5,7 @@ interface TodoFilterState extends WidgetState {
 	activeFilter?: string;
 }
 
-interface TodoFilterOptions extends WidgetOptions<TodoFilterState> { }
+type TodoFilterOptions = WidgetOptions<TodoFilterState>;
 
 type TodoFilter = Widget<TodoFilterState>;
 

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -16,7 +16,7 @@ export interface TodoFooterState extends WidgetState, StatefulChildrenState {
 	completedCount?: number;
 }
 
-export interface TodoFooterOptions extends WidgetOptions<TodoFooterState>, ParentMapMixinOptions<Child>, StatefulChildrenOptions<Child, TodoFooterState> { }
+export type TodoFooterOptions = WidgetOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
 
 export type TodoFooter = Widget<TodoFooterState> & ParentMap<Widget<TodoFooterState>>;
 

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -1,7 +1,6 @@
 import createButton from 'dojo-widgets/createButton';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
-import createParentMixin, { ParentMap, ParentMapMixinOptions } from 'dojo-widgets/mixins/createParentMapMixin';
-import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
+import createParentMapMixin, { ParentMap, ParentMapMixinOptions } from 'dojo-widgets/mixins/createParentMapMixin';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 import { Child } from 'dojo-widgets/mixins/interfaces';
 
@@ -10,41 +9,38 @@ import { h, VNode } from 'maquette';
 import createTodoFilter from './createTodoFilter';
 import { clearCompleted } from '../actions/uiTodoActions';
 
-export interface TodoFooterState extends WidgetState, StatefulChildrenState {
+export type TodoFooterState = RenderMixinState & StatefulChildrenState & {
 	activeFilter?: string;
 	activeCount?: number;
 	completedCount?: number;
-}
+};
 
-export type TodoFooterOptions = WidgetOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
+export type TodoFooterOptions = RenderMixinOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
 
-export type TodoFooter = Widget<TodoFooterState> & ParentMap<Widget<TodoFooterState>>;
+export type TodoFooter = RenderMixin<TodoFooterState> & ParentMap<RenderMixin<TodoFooterState>>;
 
-function manageChildren() {
-	const todoFooter = <TodoFooter> this;
-	const filterWidget = todoFooter.children.get('filter');
-	const buttonWidget = todoFooter.children.get('button');
+function manageChildren(this: TodoFooter) {
+	const filterWidget = this.children.get('filter');
+	const buttonWidget = this.children.get('button');
 
 	filterWidget.setState({
-		'activeFilter': todoFooter.state.activeFilter
+		activeFilter: this.state.activeFilter
 	});
 
 	const clearCompletedButtonClasses = ['clear-completed'];
-	if (todoFooter.state.completedCount === 0) {
+	if (this.state.completedCount === 0) {
 		clearCompletedButtonClasses.push('hidden');
 	}
 
 	buttonWidget.setState({
-		'classes': clearCompletedButtonClasses
+		classes: clearCompletedButtonClasses
 	});
 }
 
-const createTodoFooter = createWidget
-	.mixin(createParentMixin)
-	.mixin(createRenderableChildrenMixin)
+const createTodoFooter = createRenderMixin
 	.mixin(createStatefulChildrenMixin)
 	.mixin({
-		mixin: createParentMixin,
+		mixin: createParentMapMixin,
 		initialize(instance) {
 			const filterWidget = createTodoFilter({
 				state: {
@@ -66,25 +62,21 @@ const createTodoFooter = createWidget
 			instance.on('statechange', manageChildren);
 		}
 	})
-	.mixin({
-		mixin: {
-			getChildrenNodes(): VNode[] {
-				const todoFooter = <TodoFooter> this;
-				const activeCount = todoFooter.state.activeCount;
-				const countLabel = activeCount === 1 ? 'item' : 'items';
-
-				return [
-					h('span', {'class': 'todo-count'}, [
-						h('strong', [activeCount + ' ']),
-						h('span', [countLabel + ' left'])
-					]),
-					todoFooter.children.get('filter').render(),
-					todoFooter.children.get('button').render()
-				];
-			}
-		}
-	})
 	.extend({
+		getChildrenNodes(this: TodoFooter): VNode[] {
+			const activeCount = this.state.activeCount;
+			const countLabel = activeCount === 1 ? 'item' : 'items';
+
+			return [
+				h('span', {'class': 'todo-count'}, [
+					h('strong', [activeCount + ' ']),
+					h('span', [countLabel + ' left'])
+				]),
+				this.children.get('filter').render(),
+				this.children.get('button').render()
+			];
+		},
+
 		tagName: 'footer'
 	});
 

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -17,7 +17,7 @@ interface TodoItemState extends WidgetState, StatefulChildrenState {
 	completed?: boolean;
 }
 
-export interface TodoItemOptions extends WidgetOptions<TodoItemState>, StatefulChildrenOptions<Child, TodoItemState> { }
+export type TodoItemOptions = WidgetOptions<TodoItemState> & StatefulChildrenOptions<Child, TodoItemState>;
 
 export type TodoItem = Widget<TodoItemState>;
 

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -1,7 +1,7 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import WeakMap from 'dojo-shim/WeakMap';
 import createButton from 'dojo-widgets/createButton';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
+import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions, CreateChildrenResults, CreateChildrenResultsItem } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 import { Child } from 'dojo-widgets/mixins/interfaces';
@@ -12,14 +12,14 @@ import createCheckboxInput from './createCheckboxInput';
 import createFocusableTextInput from './createFocusableTextInput';
 import { todoRemove, todoToggleComplete, todoEdit, todoSave, todoEditInput }  from './../actions/uiTodoActions';
 
-interface TodoItemState extends WidgetState, StatefulChildrenState {
+interface TodoItemState extends RenderMixinState, StatefulChildrenState {
 	editing?: boolean;
 	completed?: boolean;
 }
 
-export type TodoItemOptions = WidgetOptions<TodoItemState> & StatefulChildrenOptions<Child, TodoItemState>;
+export type TodoItemOptions = RenderMixinOptions<TodoItemState> & StatefulChildrenOptions<Child, TodoItemState>;
 
-export type TodoItem = Widget<TodoItemState>;
+export type TodoItem = RenderMixin<TodoItemState>;
 
 export interface TodoItemFactory extends ComposeFactory<TodoItem, TodoItemOptions> { }
 
@@ -33,7 +33,7 @@ interface TodoItemChildren<C extends Child> extends CreateChildrenResults<C> {
 /**
  * Internal map of sub children IDs
  */
-const childrenMap = new WeakMap<TodoItem, TodoItemChildren<Widget<WidgetState>>>();
+const childrenMap = new WeakMap<TodoItem, TodoItemChildren<RenderMixin<any>>>();
 
 /**
  * Internal function to manage the children widgets
@@ -58,7 +58,7 @@ function manageChildren(this: TodoItem) {
 	});
 }
 
-const createTodoItem: TodoItemFactory = createWidget
+const createTodoItem: TodoItemFactory = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
@@ -88,7 +88,7 @@ const createTodoItem: TodoItemFactory = createWidget
 						}
 					},
 					label: {
-						factory: createWidget,
+						factory: createRenderMixin,
 						options: {
 							listeners: {
 								dblclick: () => { todoEdit.do(instance.state); }
@@ -109,7 +109,7 @@ const createTodoItem: TodoItemFactory = createWidget
 						}
 					}
 				})
-				.then((children: TodoItemChildren<Widget<WidgetState>>) => {
+				.then((children: TodoItemChildren<RenderMixin<any>>) => {
 					/* TODO: We are only using the label.widget but we are storing label: { id, widget }, is
 					 * that necessary? */
 					childrenMap.set(instance, children);

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -1,8 +1,6 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import WeakMap from 'dojo-shim/WeakMap';
 import createButton from 'dojo-widgets/createButton';
 import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
-import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions, CreateChildrenResults, CreateChildrenResultsItem } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 import { Child } from 'dojo-widgets/mixins/interfaces';
 
@@ -12,16 +10,14 @@ import createCheckboxInput from './createCheckboxInput';
 import createFocusableTextInput from './createFocusableTextInput';
 import { todoRemove, todoToggleComplete, todoEdit, todoSave, todoEditInput }  from './../actions/uiTodoActions';
 
-interface TodoItemState extends RenderMixinState, StatefulChildrenState {
+type TodoItemState = RenderMixinState & StatefulChildrenState & {
 	editing?: boolean;
 	completed?: boolean;
-}
+};
 
 export type TodoItemOptions = RenderMixinOptions<TodoItemState> & StatefulChildrenOptions<Child, TodoItemState>;
 
 export type TodoItem = RenderMixin<TodoItemState>;
-
-export interface TodoItemFactory extends ComposeFactory<TodoItem, TodoItemOptions> { }
 
 interface TodoItemChildren<C extends Child> extends CreateChildrenResults<C> {
 	label: CreateChildrenResultsItem<C>;
@@ -58,8 +54,7 @@ function manageChildren(this: TodoItem) {
 	});
 }
 
-const createTodoItem: TodoItemFactory = createRenderMixin
-	.mixin(createRenderableChildrenMixin)
+const createTodoItem = createRenderMixin
 	.mixin({
 		mixin: createStatefulChildrenMixin,
 		initialize(instance, options) {
@@ -128,30 +123,28 @@ const createTodoItem: TodoItemFactory = createRenderMixin
 				});
 		}
 	})
-	.mixin({
-		mixin: {
-			get classes(): string[] {
-				const todoItem: TodoItem = this;
-				const classes: string[] = [];
-				if (todoItem.state.editing) {
-					classes.push('editing');
-				}
-				return todoItem.state.completed ? ['completed', ...classes] : classes;
-			},
-			getChildrenNodes(this: TodoItem): VNode[] {
-				const { checkbox, label, button, editInput } = childrenMap.get(this);
-				return [
-					h('div.view', [
-						checkbox.widget.render(),
-						label.widget.render(),
-						button.widget.render()
-					]),
-					editInput.widget.render()
-				];
-			}
-		}
-	})
 	.extend({
+		get classes(this: TodoItem): string[] {
+			/* TODO: Deal with this in nodeAttributes when class classes are implementend */
+			const classes: string[] = [];
+			if (this.state.editing) {
+				classes.push('editing');
+			}
+			return this.state.completed ? [ 'completed', ...classes ] : classes;
+		},
+
+		getChildrenNodes(this: TodoItem): VNode[] {
+			const { checkbox, label, button, editInput } = childrenMap.get(this);
+			return [
+				h('div.view', [
+					checkbox.widget.render(),
+					label.widget.render(),
+					button.widget.render()
+				]),
+				editInput.widget.render()
+			];
+		},
+
 		tagName: 'li'
 	});
 

--- a/todo-mvc/src/widgets/createTodoList.ts
+++ b/todo-mvc/src/widgets/createTodoList.ts
@@ -1,8 +1,7 @@
 import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
-import createParentMixin, { ParentList, ParentListMixinOptions } from 'dojo-widgets/mixins/createParentListMixin';
+import createParentListMixin, { ParentList, ParentListMixinOptions } from 'dojo-widgets/mixins/createParentListMixin';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
 
 import { VNode } from 'maquette';
 import { List } from 'immutable';
@@ -13,41 +12,43 @@ interface TodoListState extends WidgetState, StatefulChildrenState {
 	activeFilter?: string;
 }
 
-interface TodoListOptions extends WidgetOptions<TodoListState>, ParentListMixinOptions<TodoItem>, StatefulChildrenOptions<Child, TodoListState> { }
+type TodoListOptions = WidgetOptions<TodoListState> & ParentListMixinOptions<TodoItem> & StatefulChildrenOptions<TodoItem, TodoListState>;
 
-export type TodoList = Widget<TodoListState> & ParentList<TodoItem>;
+export type TodoList = Widget<TodoListState> & ParentList<TodoItem> & {
+	children: List<TodoItem>;
+}
 
 function filterCompleted(children: List<TodoItem>): List<TodoItem> {
-	return <List<TodoItem>> children.filter((child: TodoItem) => {
+	return <List<TodoItem>> children.filter((child) => {
 		return child.state.completed;
 	});
 }
 
 function filterActive(children: List<TodoItem>): List<TodoItem> {
-	return <List<TodoItem>> children.filter((child: TodoItem) => {
+	return <List<TodoItem>> children.filter((child) => {
 		return !child.state.completed;
 	});
 }
 
 const createTodoList = createWidget
-	.mixin(createParentMixin)
+	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
 	.extend({
 		tagName: 'ul',
 
-		getChildrenNodes(): (VNode | string)[] {
-			const todoList: TodoList = this;
+		getChildrenNodes(this: TodoList): (VNode | string)[] {
 			const results: (VNode | string)[] = [];
-			const { children } = todoList;
-			let filteredChildren: List<TodoItem> = children;
+			const { children } = this;
+			let filteredChildren = children;
 
-			if (todoList.state.activeFilter === 'completed') {
+			if (this.state.activeFilter === 'completed') {
 				filteredChildren = filterCompleted(children);
-			} else if (todoList.state.activeFilter === 'active') {
+			}
+			else if (this.state.activeFilter === 'active') {
 				filteredChildren = filterActive(children);
 			}
-			filteredChildren.forEach((child: Child) => results.push(child.render()));
+			filteredChildren.forEach((child) => results.push(child.render()));
 			return results;
 		}
 	});

--- a/todo-mvc/src/widgets/createTodoList.ts
+++ b/todo-mvc/src/widgets/createTodoList.ts
@@ -1,6 +1,5 @@
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createParentListMixin, { ParentList, ParentListMixinOptions } from 'dojo-widgets/mixins/createParentListMixin';
-import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import { VNode } from 'maquette';
@@ -8,15 +7,15 @@ import { List } from 'immutable';
 
 import { TodoItem } from './createTodoItem';
 
-interface TodoListState extends WidgetState, StatefulChildrenState {
+type TodoListState = RenderMixinState & StatefulChildrenState & {
 	activeFilter?: string;
-}
+};
 
-type TodoListOptions = WidgetOptions<TodoListState> & ParentListMixinOptions<TodoItem> & StatefulChildrenOptions<TodoItem, TodoListState>;
+type TodoListOptions = RenderMixinOptions<TodoListState> & ParentListMixinOptions<TodoItem> & StatefulChildrenOptions<TodoItem, TodoListState>;
 
-export type TodoList = Widget<TodoListState> & ParentList<TodoItem> & {
+export type TodoList = RenderMixin<TodoListState> & ParentList<TodoItem> & {
 	children: List<TodoItem>;
-}
+};
 
 function filterCompleted(children: List<TodoItem>): List<TodoItem> {
 	return <List<TodoItem>> children.filter((child) => {
@@ -30,13 +29,10 @@ function filterActive(children: List<TodoItem>): List<TodoItem> {
 	});
 }
 
-const createTodoList = createWidget
+const createTodoList = createRenderMixin
 	.mixin(createParentListMixin)
-	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
 	.extend({
-		tagName: 'ul',
-
 		getChildrenNodes(this: TodoList): (VNode | string)[] {
 			const results: (VNode | string)[] = [];
 			const { children } = this;
@@ -50,7 +46,9 @@ const createTodoList = createWidget
 			}
 			filteredChildren.forEach((child) => results.push(child.render()));
 			return results;
-		}
+		},
+
+		tagName: 'ul'
 	});
 
 export default createTodoList;


### PR DESCRIPTION
This PR refactors `todo-mvc` to take advantage of the features being proposed in dojo/widgets#40 and dojo/compose#59.

Currently the CI will fail for this PR until those are merged and published, but the functional tests are passing when running locally against those branches.

Todo:

- [x] Review and update other code to follow "best practices" with changes in those PRs

Fixes #44 