### PR TITLE
monster-cards refactor for nodeAttributes

### DIFF
--- a/monster-cards/package.json
+++ b/monster-cards/package.json
@@ -17,19 +17,19 @@
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
     "dojo-actions": "2.0.0-alpha.8",
-    "dojo-app": "2.0.0-alpha.5",
-    "dojo-compose": "2.0.0-beta.10",
-    "dojo-core": "2.0.0-alpha.12",
+    "dojo-app": ">=2.0.0-alpha.6",
+    "dojo-compose": ">=2.0.0-beta.11",
+    "dojo-core": ">=2.0.0-alpha.13",
     "dojo-dom": "2.0.0-alpha.5",
     "dojo-has": "2.0.0-alpha.4",
     "dojo-loader": "2.0.0-beta.7",
     "dojo-routing": "2.0.0-alpha.5",
     "dojo-shim": "2.0.0-alpha.4",
     "dojo-stores": "2.0.0-alpha.1",
-    "dojo-widgets": "2.0.0-alpha.8",
+    "dojo-widgets": ">=2.0.0-alpha.9",
     "font-awesome": "^4.6.3",
-    "immutable": "3.8.1",
-    "maquette": "2.3.2"
+    "immutable": "^3.8.1",
+    "maquette": "^2.3.2"
   },
   "devDependencies": {
     "codecov.io": "^0.1.6",
@@ -45,6 +45,6 @@
     "intern": "^3.2.3",
     "remap-istanbul": "^0.6.4",
     "tslint": "next",
-    "typescript": "2.0.2"
+    "typescript": "^2.0.3"
   }
 }

--- a/monster-cards/src/index.ts
+++ b/monster-cards/src/index.ts
@@ -1,4 +1,4 @@
-(<DojoLoader.RootRequire> require).config({
+require.config({
 	baseUrl: '../../',
 	packages: [
 		{ name: 'src', location: '_build/src' },

--- a/monster-cards/src/main.ts
+++ b/monster-cards/src/main.ts
@@ -48,4 +48,9 @@ app.loadDefinition({
 	]
 });
 
-app.realize(document.body);
+app
+	.realize(document.body)
+	.catch((err) => {
+		/* Report any realization errors */
+		console.error(err);
+	});

--- a/monster-cards/src/widgets/common/createIcon.ts
+++ b/monster-cards/src/widgets/common/createIcon.ts
@@ -1,11 +1,6 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
 
-export type Icon = Widget<WidgetState>;
-
-export interface IconFactory extends ComposeFactory<Icon, WidgetOptions<WidgetState>> { }
-
-const createIcon: IconFactory = createWidget
+const createIcon = createRenderMixin
 	.extend({
 		tagName: 'i'
 	});

--- a/monster-cards/src/widgets/common/createIconMenuItem.ts
+++ b/monster-cards/src/widgets/common/createIconMenuItem.ts
@@ -1,30 +1,29 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createStatefulChildrenMixin, { StatefulChildren,  StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 import { Child } from 'dojo-widgets/mixins/interfaces';
 
 import createIcon from './createIcon';
 
-interface IconMenuItemState extends WidgetState, StatefulChildrenState {
+type IconMenuItemState = RenderMixinState & StatefulChildrenState & {
 	icon?: string[];
-}
+};
 
-export interface IconMenuItemOptions extends WidgetOptions<IconMenuItemState>, StatefulChildrenOptions<Child, IconMenuItemState> { }
+type IconMenuItemOptions = RenderMixinOptions<IconMenuItemState> & StatefulChildrenOptions<Child, IconMenuItemState>;
 
-export type IconMenuItem = Widget<IconMenuItemState> & StatefulChildren<Child, IconMenuItemState>;
+type IconMenuItem = RenderMixin<IconMenuItemState> & StatefulChildren<Child>;
 
-export interface IconMenuItemFactory extends ComposeFactory<IconMenuItem, IconMenuItemOptions> { }
-
-const createIconMenuItem: IconMenuItemFactory = createWidget
+const createIconMenuItem = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
 		initialize(instance: IconMenuItem, options: IconMenuItemOptions) {
 			const classes = options && options.state && options.state.icon || [];
-			instance.createChild(createIcon, { state: { classes } }).then(() => {
-				instance.invalidate();
-			});
+			instance
+				.createChild(createIcon, { state: { classes } })
+				.then(() => {
+					instance.invalidate();
+				});
 		}
 	})
 	.extend({

--- a/monster-cards/src/widgets/common/createImage.ts
+++ b/monster-cards/src/widgets/common/createImage.ts
@@ -1,34 +1,26 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import { VNodeProperties } from 'maquette';
-import createCachedRenderMixin from 'dojo-widgets/mixins/createCachedRenderMixin';
 
-export interface ImageState extends WidgetState {
+type ImageState = RenderMixinState & {
 	src?: string;
-}
+};
 
-export interface ImageOptions extends WidgetOptions<ImageState> { }
+type ImageOptions = RenderMixinOptions<ImageState>;
 
-export type Image = Widget<ImageState>;
+type Image = RenderMixin<ImageState>;
 
-export interface ImageFactory extends ComposeFactory<Image, ImageOptions> { }
+type ImageFactory = ComposeFactory<Image, ImageOptions>;
 
-const createImage: ImageFactory = createWidget
-	.mixin({
-		mixin: createCachedRenderMixin,
-		aspectAdvice: {
-			before: {
-				getNodeAttributes(this: Image, overrides: VNodeProperties = {}): VNodeProperties[] {
-					if (this.state.src !== undefined) {
-						overrides.src = this.state.src;
-					}
-
-					return [ overrides ];
-				}
-			}
-		}
-	})
+const createImage: ImageFactory = createRenderMixin
 	.extend({
+		nodeAttributes: [
+			function (this: Image): VNodeProperties {
+				const { src } = this.state;
+				return src ? { src } : {};
+			}
+		],
+
 		tagName: 'img'
 	});
 

--- a/monster-cards/src/widgets/common/createLink.ts
+++ b/monster-cards/src/widgets/common/createLink.ts
@@ -1,34 +1,26 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
+import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import { VNodeProperties } from 'maquette';
-import createCachedRenderMixin from 'dojo-widgets/mixins/createCachedRenderMixin';
 
-export interface LinkState extends WidgetState {
+export type LinkState = RenderMixinState & {
 	href?: string;
 }
 
-export interface LinkOptions extends WidgetOptions<LinkState> { }
+type LinkOptions = RenderMixinOptions<LinkState>;
 
-export type Link = Widget<LinkState>;
+export type Link = RenderMixin<LinkState>;
 
-export interface LinkFactory extends ComposeFactory<Link, LinkOptions> { }
+type LinkFactory = ComposeFactory<Link, LinkOptions>;
 
-const createLink: LinkFactory = createWidget
-	.mixin({
-		mixin: createCachedRenderMixin,
-		aspectAdvice: {
-			before: {
-				getNodeAttributes(this: Link, overrides: VNodeProperties = {}): VNodeProperties[] {
-					if (this.state.href !== undefined) {
-						overrides['href'] = this.state.href;
-					}
-
-					return [overrides];
-				}
-			}
-		}
-	})
+const createLink: LinkFactory = createRenderMixin
 	.extend({
+		nodeAttributes: [
+			function (this: Link): VNodeProperties {
+				const { href } = this.state;
+				return href ? { href } : {};
+			}
+		],
+
 		tagName: 'a'
 	});
 

--- a/monster-cards/src/widgets/common/createLinkMenuItem.ts
+++ b/monster-cards/src/widgets/common/createLinkMenuItem.ts
@@ -1,29 +1,29 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
-import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
+import createRenderableChildrenMixin, { RenderableChildrenMixin, RenderableChildrenOptions } from 'dojo-widgets/mixins/createRenderableChildrenMixin';
+import createRenderMixin, { RenderMixin, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
 import createStatefulChildrenMixin, { StatefulChildren, StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 import { Child } from 'dojo-widgets/mixins/interfaces';
 
 import createLink, { LinkState } from './createLink';
 
-interface LinkMenuItemState extends LinkState, StatefulChildrenState {}
+type LinkMenuItemState = LinkState & StatefulChildrenState;
 
-export interface LinkMenuItemOptions extends WidgetOptions<LinkMenuItemState>, StatefulChildrenOptions<Child, LinkMenuItemState> { }
+type LinkMenuItemOptions = RenderMixinOptions<LinkMenuItemState> & RenderableChildrenOptions & StatefulChildrenOptions<Child, LinkMenuItemState>;
 
-export type LinkMenuItem = Widget<WidgetState> & StatefulChildren<Child, LinkMenuItemState>;
+type LinkMenuItem = RenderMixin<LinkMenuItemState> & RenderableChildrenMixin & StatefulChildren<Child>;
 
-export interface LinkMenuItemFactory extends ComposeFactory<LinkMenuItem, LinkMenuItemOptions> { }
+type LinkMenuItemFactory = ComposeFactory<LinkMenuItem, LinkMenuItemOptions>;
 
-const createLinkMenuItem: LinkMenuItemFactory = createWidget
+const createLinkMenuItem: LinkMenuItemFactory = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance: LinkMenuItem, options: LinkMenuItemOptions) {
-			const state: LinkMenuItemState = options && options.state || undefined;
-
-			instance.createChild(createLink, { state }).then(() => {
-				instance.invalidate();
-			});
+		initialize(instance: LinkMenuItem, { state }: LinkMenuItemOptions = {}) {
+			instance
+				.createChild(createLink, { state })
+				.then(() => {
+					instance.invalidate();
+				});
 		}
 	})
 	.extend({

--- a/monster-cards/src/widgets/common/createSearchInput.ts
+++ b/monster-cards/src/widgets/common/createSearchInput.ts
@@ -1,44 +1,35 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createTextInput from 'dojo-widgets/createTextInput';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createIcon from './createIcon';
 
-interface SearchInputState extends WidgetState, StatefulChildrenState { }
-
-export interface SearchInputOptions extends WidgetOptions<SearchInputState>, StatefulChildrenOptions<Child, SearchInputState> { }
-
-export type SearchInput = Widget<SearchInputState>;
-
-export interface SearchInputFactory extends ComposeFactory<SearchInput, SearchInputOptions> { }
-
-const createSearchInput: SearchInputFactory = createWidget
+const createSearchInput = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
-			instance.createChildren({
-				searchInput: {
-					factory: createTextInput,
-					options: {
-						type: 'search'
-					}
-				},
-				searchIcon: {
-					factory: createIcon,
-					options: {
-						state: {
-							classes: [ 'fa', 'fa-search' ]
+		initialize(instance) {
+			instance
+				.createChildren({
+					searchInput: {
+						factory: createTextInput,
+						options: {
+							type: 'search'
+						}
+					},
+					searchIcon: {
+						factory: createIcon,
+						options: {
+							state: {
+								classes: [ 'fa', 'fa-search' ]
+							}
 						}
 					}
-				}
-			})
-			.then(() => {
-				instance.invalidate();
-			});
+				})
+				.then(() => {
+					instance.invalidate();
+				});
 		}
 	})
 	.extend({

--- a/monster-cards/src/widgets/footer/createFooter.ts
+++ b/monster-cards/src/widgets/footer/createFooter.ts
@@ -1,25 +1,15 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createFooterIcons from './createFooterIcons';
 import createImage from './../common/createImage';
 
-interface FooterState extends WidgetState, StatefulChildrenState { }
-
-export interface FooterOptions extends WidgetOptions<FooterState>, StatefulChildrenOptions<Child, FooterState> { }
-
-export type Footer = Widget<FooterState>;
-
-export interface FooterFactory extends ComposeFactory<Footer, FooterOptions> { }
-
-const createFooter: FooterFactory = createWidget
+const createFooter = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
+		initialize(instance) {
 			instance
 				.createChildren({
 					navMenu: {
@@ -43,7 +33,8 @@ const createFooter: FooterFactory = createWidget
 					instance.invalidate();
 				});
 		}
-	}).extend({
+	})
+	.extend({
 		tagName: 'footer'
 	});
 

--- a/monster-cards/src/widgets/footer/createFooterIcons.ts
+++ b/monster-cards/src/widgets/footer/createFooterIcons.ts
@@ -1,25 +1,14 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions }  from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin  from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createIconMenuItem from './../common/createIconMenuItem';
 
-interface FooterIconsState extends WidgetState, StatefulChildrenState {}
-
-export interface FooterIconsOptions extends WidgetOptions<FooterIconsState>, StatefulChildrenOptions<Child, FooterIconsState> { }
-
-export type FooterIcons = Widget<FooterIconsState>;
-
-export interface FooterIconsFactory extends ComposeFactory<FooterIcons, FooterIconsOptions> { }
-
-const createFooterIcons: FooterIconsFactory = createWidget
+const createFooterIcons = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
+		initialize(instance) {
 			instance
 				.createChildren({
 					facebookIcon: {

--- a/monster-cards/src/widgets/navbar/createNavActions.ts
+++ b/monster-cards/src/widgets/navbar/createNavActions.ts
@@ -1,47 +1,37 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions }  from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createSearchInput from './../common/createSearchInput';
 import createIconMenuItem from './../common/createIconMenuItem';
 
-interface NavActionsState extends WidgetState, StatefulChildrenState {}
-
-export interface NavActionsOptions extends WidgetOptions<NavActionsState>, StatefulChildrenOptions<Child, NavActionsState> { }
-
-export type NavActions = Widget<NavActionsState>;
-
-export interface NavActionsFactory extends ComposeFactory<NavActions, NavActionsOptions> { }
-
-const createNavActions: NavActionsFactory = createWidget
+const createNavActions = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
-			instance.createChildren({
-				searchInput: {
-					factory: createSearchInput,
-					options: {
-						state: {
-							classes: [ 'search' ]
+		initialize(instance) {
+			instance
+				.createChildren({
+					searchInput: {
+						factory: createSearchInput,
+						options: {
+							state: {
+								classes: [ 'search' ]
+							}
+						}
+					},
+					favIcon: {
+						factory: createIconMenuItem,
+						options: {
+							state: {
+								icon: [ 'fa', 'fa-2x', 'fa-heart-o' ]
+							}
 						}
 					}
-				},
-				favIcon: {
-					factory: createIconMenuItem,
-					options: {
-						state: {
-							icon: [ 'fa', 'fa-2x', 'fa-heart-o' ]
-						}
-					}
-				}
-			})
-			.then(() => {
-				instance.invalidate();
-			});
+				})
+				.then(() => {
+					instance.invalidate();
+				});
 		}
 	})
 	.extend({

--- a/monster-cards/src/widgets/navbar/createNavMenu.ts
+++ b/monster-cards/src/widgets/navbar/createNavMenu.ts
@@ -1,26 +1,15 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions }  from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createIconMenuItem from './../common/createIconMenuItem';
 import createLinkMenuItem from './../common/createLinkMenuItem';
 
-interface NavMenuState extends WidgetState, StatefulChildrenState {}
-
-export interface NavMenuOptions extends WidgetOptions<NavMenuState>, StatefulChildrenOptions<Child, NavMenuState> { }
-
-export type NavMenu = Widget<NavMenuState>;
-
-export interface NavMenuFactory extends ComposeFactory<NavMenu, NavMenuOptions> { }
-
-const createNavMenu: NavMenuFactory = createWidget
+const createNavMenu = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
+		initialize(instance) {
 			instance
 				.createChildren({
 					appIcon: {

--- a/monster-cards/src/widgets/navbar/createNavbar.ts
+++ b/monster-cards/src/widgets/navbar/createNavbar.ts
@@ -1,25 +1,15 @@
-import { ComposeFactory } from 'dojo-compose/compose';
-import createWidget, { Widget, WidgetState, WidgetOptions } from 'dojo-widgets/createWidget';
 import createRenderableChildrenMixin from 'dojo-widgets/mixins/createRenderableChildrenMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
+import createRenderMixin from 'dojo-widgets/mixins/createRenderMixin';
+import createStatefulChildrenMixin from 'dojo-widgets/mixins/createStatefulChildrenMixin';
 
 import createNavMenu from './createNavMenu';
 import createNavActions from './createNavActions';
 
-interface NavbarState extends WidgetState, StatefulChildrenState { }
-
-export interface NavbarOptions extends WidgetOptions<NavbarState>, StatefulChildrenOptions<Child, NavbarState> { }
-
-export type Navbar = Widget<WidgetState>;
-
-export interface NavbarFactory extends ComposeFactory<Navbar, NavbarOptions> { }
-
-const createNavbar: NavbarFactory = createWidget
+const createNavbar = createRenderMixin
 	.mixin(createRenderableChildrenMixin)
 	.mixin({
 		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
+		initialize(instance) {
 			instance
 				.createChildren({
 					navMenu: {
@@ -43,7 +33,8 @@ const createNavbar: NavbarFactory = createWidget
 					instance.invalidate();
 				});
 		}
-	}).extend({
+	})
+	.extend({
 		tagName: 'header'
 	});
 


### PR DESCRIPTION
This PR also covers other changes made to widget to support `nodeAttributes` and starts to follow the ideal pattern for creating custom widgets.

This will not pass CI until `dojo-widgets` is published with dojo/widgets#40 included in it.