### PR TITLE
Incorporate `dojo-i18n` into todo-mvc.

### DIFF
--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -39,6 +39,7 @@
     "dojo-compose": ">=2.0.0-beta.13",
     "dojo-core": ">=2.0.0-alpha.15",
     "dojo-dom": ">=2.0.0-alpha.5",
+    "dojo-i18n": "^2.0.0-alpha.1",
     "dojo-has": ">=2.0.0-alpha.5",
     "dojo-loader": ">=2.0.0-beta.7",
     "dojo-routing": ">=2.0.0-alpha.5",

--- a/todo-mvc/src/index.html
+++ b/todo-mvc/src/index.html
@@ -24,7 +24,7 @@
 		</section>
 		<footer class="info">
 			<app-projector>
-				<app-widget id="footer-instructions" data-factory="dojo-widgets/createWidget"></app-widget>
+				<app-widget id="footer-instructions" data-factory="src/widgets/createTextWidget"></app-widget>
 			</app-projector>
 			<p>Credits:
 				<a href="https://github.com/matt-gadd">Matt Gadd</a>,

--- a/todo-mvc/src/index.html
+++ b/todo-mvc/src/index.html
@@ -23,7 +23,9 @@
 			</app-projector>
 		</section>
 		<footer class="info">
-			<p>Double-click to edit a todo</p>
+			<app-projector>
+				<app-widget id="footer-instructions" data-factory="dojo-widgets/createWidget"></app-widget>
+			</app-projector>
 			<p>Credits:
 				<a href="https://github.com/matt-gadd">Matt Gadd</a>,
 				<a href="https://github.com/agubler">Anthony Gubler</a>

--- a/todo-mvc/src/index.ts
+++ b/todo-mvc/src/index.ts
@@ -2,6 +2,7 @@ require.config({
 	baseUrl: '../../',
 	packages: [
 		{ name: 'src', location: '_build/src' },
+		{ name: 'nls', location: '_build/src/nls' },
 		{ name: 'dojo-actions', location: 'node_modules/dojo-actions' },
 		{ name: 'dojo-app', location: 'node_modules/dojo-app' },
 		{ name: 'dojo-dom', location: 'node_modules/dojo-dom' },
@@ -10,6 +11,7 @@ require.config({
 		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+		{ name: 'dojo-i18n', location: 'node_modules/dojo-i18n' },
 		{ name: 'dojo-stores', location: 'node_modules/dojo-stores' },
 		{ name: 'dojo-widgets', location: 'node_modules/dojo-widgets' },
 		{ name: 'immutable', location: 'node_modules/immutable/dist', main: 'immutable' },

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,5 +1,6 @@
 import createApp from 'dojo-app/createApp';
 import global from 'dojo-core/global';
+import { switchLocale } from 'dojo-i18n/i18n';
 import ShimPromise from 'dojo-shim/Promise';
 import createPanel from 'dojo-widgets/createPanel';
 import createWidget from 'dojo-widgets/createWidget';

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,6 +1,5 @@
 import createApp from 'dojo-app/createApp';
 import global from 'dojo-core/global';
-import { switchLocale } from 'dojo-i18n/i18n';
 import ShimPromise from 'dojo-shim/Promise';
 import createPanel from 'dojo-widgets/createPanel';
 import createWidget from 'dojo-widgets/createWidget';

--- a/todo-mvc/src/nls/en-PA/main.ts
+++ b/todo-mvc/src/nls/en-PA/main.ts
@@ -1,0 +1,9 @@
+const messages = {
+	// TODO: The following will be updated with an ICU-compat message once support
+	// is added to `dojo-i18n`.
+	itemLeft: 'thing you won\'t really do',
+	itemsLeft: 'things you won\'t really do',
+
+	newTodoPlaceholder: 'What can\'t you do without a reminder?'
+};
+export default messages;

--- a/todo-mvc/src/nls/main.ts
+++ b/todo-mvc/src/nls/main.ts
@@ -1,0 +1,18 @@
+const bundlePath = 'nls/main';
+const locales: string[] = [ 'en-PA' ];
+const messages = {
+	active: 'Active',
+	all: 'All',
+	clearCompleted: 'Clear completed',
+	completed: 'Completed',
+	instructions: 'Double-click to edit a todo',
+
+	// TODO: The following will be updated with an ICU-compat message once support
+	// is added to `dojo-i18n`.
+	itemLeft: 'item left',
+	itemsLeft: 'items left',
+
+	newTodoPlaceholder: 'What needs to be done?'
+};
+
+export default { bundlePath, locales, messages };

--- a/todo-mvc/src/stores/widgetStore.ts
+++ b/todo-mvc/src/stores/widgetStore.ts
@@ -10,7 +10,9 @@ export default createMemoryStore({
 			id: 'new-todo',
 			classes: ['new-todo'],
 			focused: true,
-			placeholder: 'What needs to be done?'
+			labels: {
+				placeholder: 'nls/main:newTodoPlaceholder'
+			}
 		},
 		{
 			id: 'main-section',
@@ -32,6 +34,12 @@ export default createMemoryStore({
 			completedCount: 0,
 			activeCount: 0,
 			activeFilter: 'all'
+		},
+		{
+			id: 'footer-instructions',
+			labels: {
+				label: 'nls/main:instructions'
+			}
 		}
 	]
 });

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -3,6 +3,7 @@ import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldM
 import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'maquette';
+import bundle from '../nls/main';
 
 /* I suspect this needs to go somewhere else */
 export interface TypedTargetEvent<T extends EventTarget> extends Event {
@@ -50,8 +51,8 @@ const createFocusableTextInput = createRenderMixin
 			}
 		],
 
+		bundles: [ bundle ],
 		tagName: 'input',
-
 		type: 'text'
 	});
 

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -1,5 +1,7 @@
+import { Messages } from 'dojo-i18n/i18n';
 import WeakMap from 'dojo-shim/WeakMap';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
+import createI18nMixin, { I18nMixin, I18nOptions, I18nState } from 'dojo-widgets/mixins/createI18nMixin';
 import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'maquette';
@@ -10,14 +12,14 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export type FocusableTextInputState = RenderMixinState & FormFieldMixinState<string> & {
+export type FocusableTextInputState = RenderMixinState & FormFieldMixinState<string> & I18nState & {
 	focused?: boolean;
 	placeholder?: string;
 };
 
-export type FocusableTextInputOptions = RenderMixinOptions<FocusableTextInputState> & FormFieldMixinOptions<string, FocusableTextInputState>;
+export type FocusableTextInputOptions = RenderMixinOptions<FocusableTextInputState> & FormFieldMixinOptions<string, FocusableTextInputState> & I18nOptions;
 
-export type FocusableTextInput = RenderMixin<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState> & VNodeEvented;
+export type FocusableTextInput = RenderMixin<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState> & VNodeEvented & I18nMixin<Messages, I18nState>;
 
 const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInputElement): void}>();
 
@@ -33,6 +35,7 @@ function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 
 const createFocusableTextInput = createRenderMixin
 	.mixin(createFormFieldMixin)
+	.mixin(createI18nMixin)
 	.mixin({
 		mixin: createVNodeEvented,
 		initialize(instance) {

--- a/todo-mvc/src/widgets/createTextWidget.ts
+++ b/todo-mvc/src/widgets/createTextWidget.ts
@@ -1,0 +1,13 @@
+import createWidget from 'dojo-widgets/createWidget';
+import createI18nMixin from 'dojo-widgets/mixins/createI18nMixin';
+import bundle from '../nls/main';
+
+const createTextWidget = createWidget
+	.mixin({
+		mixin: createI18nMixin,
+		initialize(instance) {
+			instance.registerBundle(bundle);
+		}
+	});
+
+export default createTextWidget;

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -1,5 +1,6 @@
 import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
 import { h, VNode } from 'maquette';
+import bundle from '../nls/main';
 
 type TodoFilterState = RenderMixinState & {
 	activeFilter?: string;
@@ -13,10 +14,11 @@ const createTodoFilter = createRenderMixin
 	.extend({
 		getChildrenNodes(this: TodoFilter): VNode[] {
 			const { activeFilter } = this.state;
+			const messages = this.localizeBundle(bundle);
 			return [
 				h('li', {}, [
 					h('a', {
-						innerHTML: 'All',
+						innerHTML: messages['all'],
 						href: '#all',
 						classes: {
 							selected: activeFilter === 'all'
@@ -25,7 +27,7 @@ const createTodoFilter = createRenderMixin
 				]),
 				h('li', {}, [
 					h('a', {
-						innerHTML: 'Active',
+						innerHTML: messages['active'],
 						href: '#active',
 						classes: {
 							selected: activeFilter === 'active'
@@ -34,7 +36,7 @@ const createTodoFilter = createRenderMixin
 				]),
 				h('li', {}, [
 					h('a', {
-						innerHTML: 'Completed',
+						innerHTML: messages['completed'],
 						href: '#completed',
 						classes: {
 							selected: activeFilter === 'completed'
@@ -44,6 +46,7 @@ const createTodoFilter = createRenderMixin
 			];
 		},
 
+		bundles: [ bundle ],
 		tagName: 'ul'
 	});
 

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -1,3 +1,5 @@
+import { Messages } from 'dojo-i18n/i18n';
+import createI18nMixin, { I18nMixin, I18nOptions, I18nState } from 'dojo-widgets/mixins/createI18nMixin';
 import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
 import { h, VNode } from 'maquette';
 import bundle from '../nls/main';
@@ -6,11 +8,12 @@ type TodoFilterState = RenderMixinState & {
 	activeFilter?: string;
 };
 
-type TodoFilterOptions = RenderMixinOptions<TodoFilterState>;
+type TodoFilterOptions = RenderMixinOptions<TodoFilterState> & I18nOptions;
 
-type TodoFilter = RenderMixin<TodoFilterState>;
+type TodoFilter = RenderMixin<TodoFilterState> & I18nMixin<Messages, I18nState>;
 
 const createTodoFilter = createRenderMixin
+	.mixin(createI18nMixin)
 	.extend({
 		getChildrenNodes(this: TodoFilter): VNode[] {
 			const { activeFilter } = this.state;

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -1,4 +1,6 @@
+import { Messages } from 'dojo-i18n/i18n';
 import createButton from 'dojo-widgets/createButton';
+import createI18nMixin, { I18nMixin, I18nOptions, I18nState } from 'dojo-widgets/mixins/createI18nMixin';
 import createParentMapMixin, { ParentMap, ParentMapMixinOptions } from 'dojo-widgets/mixins/createParentMapMixin';
 import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
 import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
@@ -16,9 +18,9 @@ export type TodoFooterState = RenderMixinState & StatefulChildrenState & {
 	completedCount?: number;
 };
 
-export type TodoFooterOptions = RenderMixinOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
+export type TodoFooterOptions = I18nOptions & RenderMixinOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
 
-export type TodoFooter = RenderMixin<TodoFooterState> & ParentMap<RenderMixin<TodoFooterState>>;
+export type TodoFooter = RenderMixin<TodoFooterState> & ParentMap<RenderMixin<TodoFooterState>> & I18nMixin<Messages, I18nState>;
 
 function manageChildren(this: TodoFooter) {
 	const filterWidget = this.children.get('filter');
@@ -40,6 +42,7 @@ function manageChildren(this: TodoFooter) {
 
 const createTodoFooter = createRenderMixin
 	.mixin(createStatefulChildrenMixin)
+	.mixin(createI18nMixin)
 	.mixin({
 		mixin: createParentMapMixin,
 		initialize(instance, options) {

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -7,6 +7,7 @@ import { Child } from 'dojo-widgets/mixins/interfaces';
 import { h, VNode } from 'maquette';
 
 import { clearCompleted } from '../actions/userActions';
+import bundle from '../nls/main';
 import createTodoFilter from './createTodoFilter';
 
 export type TodoFooterState = RenderMixinState & StatefulChildrenState & {
@@ -49,10 +50,13 @@ const createTodoFooter = createRenderMixin
 				}
 			});
 			const clearCompletedButton = createButton({
+				bundles: [ bundle ],
 				state: {
 					id: 'button',
-					label: 'Clear completed',
-					classes: ['clear-completed']
+					classes: ['clear-completed'],
+					labels: {
+						label: 'nls/main:clearCompleted'
+					}
 				},
 				listeners: {
 					click: clearCompleted
@@ -65,18 +69,20 @@ const createTodoFooter = createRenderMixin
 	.extend({
 		getChildrenNodes(this: TodoFooter): VNode[] {
 			const activeCount = this.state.activeCount;
-			const countLabel = activeCount === 1 ? 'item' : 'items';
+			const messages = this.localizeBundle(bundle);
+			const countLabel = activeCount === 1 ? 'itemLeft' : 'itemsLeft';
 
 			return [
 				h('span', {'class': 'todo-count'}, [
 					h('strong', [activeCount + ' ']),
-					h('span', [countLabel + ' left'])
+					h('span', [ messages[countLabel] ])
 				]),
 				this.children.get('filter').render(),
 				this.children.get('button').render()
 			];
 		},
 
+		bundles: [ bundle ],
 		tagName: 'footer'
 	});
 

--- a/todo-mvc/tests/intern.ts
+++ b/todo-mvc/tests/intern.ts
@@ -60,6 +60,7 @@ export const loaderOptions = {
 		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
 		{ name: 'dojo-dom', location: 'node_modules/dojo-dom' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+		{ name: 'dojo-i18n', location: 'node_modules/dojo-i18n' },
 		{ name: 'dojo-routing', location: 'node_modules/dojo-routing' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
 		{ name: 'dojo-stores', location: 'node_modules/dojo-stores' },


### PR DESCRIPTION
- Move messages into the `nls/main` bundle.
- Update widgets to use either `state.labels` or `localizeBundle` for
  retrieving messages.
- Convert the footer instructions into a widget to allow its text to be
  internationalized as well.

Blocked [`dojo-widgets` #81](https://github.com/dojo/widgets/issues/81), which is in turn blocked by [`dojo-i18n` #19](https://github.com/dojo/i18n/issues/19).
