### PR TITLE
Add 'test' index.html

### DIFF
--- a/monster-cards/src/index.html
+++ b/monster-cards/src/index.html
@@ -5,8 +5,6 @@
 		<title>dojo2 Monster Cards</title>
 	</head>
 	<body>
-		<script src="./../../node_modules/dojo-loader/loader.min.js"></script>
-		<script src="./index.js"></script>
 		<app-projector data-css-transitions="true">
 			<header is="app-widget" data-uid="navbar"></header>
 			<main>

--- a/todo-mvc/Gruntfile.js
+++ b/todo-mvc/Gruntfile.js
@@ -1,6 +1,7 @@
 module.exports = function (grunt) {
 
 	var staticFiles = [ 'src/**/*.html', 'src/**/*.css' ];
+	var testFiles = [ 'tests/support/index.html' ];
 
 	require('grunt-dojo2').initConfig(grunt, {
 		ts: {
@@ -16,6 +17,13 @@ module.exports = function (grunt) {
 				cwd: '.',
 				src: staticFiles,
 				dest: '<%= devDirectory %>'
+			},
+			testIndexFiles: {
+				expand: false,
+				flatten: true,
+				cwd: '.',
+				src: testFiles,
+				dest: '<%= devDirectory %>src/index.html'
 			}
 		}
 	});
@@ -26,7 +34,8 @@ module.exports = function (grunt) {
 		'tslint',
 		'clean:dev',
 		'ts:dev',
-		'copy:staticFiles'
+		'copy:staticFiles',
+		'copy:testIndexFiles'
 	]);
 
 	grunt.registerTask('ci', [

--- a/todo-mvc/tests/support/index.html
+++ b/todo-mvc/tests/support/index.html
@@ -5,6 +5,8 @@
 		<title>dojo2 todo mvc</title>
 	</head>
 	<body>
+		<script src="./../../node_modules/dojo-loader/loader.min.js"></script>
+		<script src="./index.js"></script>
 		<section class="todoapp">
 			<header>
 				<app-projector>


### PR DESCRIPTION
To stop errors when consumers are building and running the app using webpack - still need to use the AMD loader for the functional tests, so copy over a tests `index.html` with the required script tags for tests