### PR TITLE
todoMVC: Migrate to @types and integrate dojo-interfaces.

### DIFF
--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -4,6 +4,7 @@
   "description": "TodoMVC using Dojo2",
   "main": "index.js",
   "scripts": {
+    "prepublish": "grunt peerDepInstall",
     "test": "grunt test"
   },
   "repository": {
@@ -15,10 +16,24 @@
     "node": ">=6",
     "npm": ">=3"
   },
+  "peerDependencies": {
+    "dojo-core": ">=2.0.0-alpha.16",
+    "dojo-app": ">=2.0.0-alpha.8",
+    "dojo-dom": ">=2.0.0-alpha.5",
+    "dojo-actions": ">=2.0.0-alpha.9",
+    "dojo-routing": ">=2.0.0-alpha.5",
+    "dojo-stores": ">=2.0.0-alpha.3",
+    "dojo-widgets": ">=2.0.0-alpha.10",
+    "dojo-compose": ">=2.0.0-beta.13",
+    "dojo-has": ">=2.0.0-alpha.5",
+    "dojo-shim": ">=2.0.0-beta.3",
+    "dojo-interfaces": ">=2.0.0-alpha.4"
+  },
   "devDependencies": {
     "codecov.io": "^0.1.6",
     "dojo-cli-build-webpack": ">=2.0.0-alpha.2",
     "dts-generator": "^1.7.0",
+    "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
@@ -30,21 +45,11 @@
     "intern": "^3.2.3",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.3"
+    "typescript": "~2.0.3",
+    "@types/node": "^6.0.46"
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
-    "dojo-actions": ">=2.0.0-alpha.9",
-    "dojo-app": ">=2.0.0-alpha.8",
-    "dojo-compose": ">=2.0.0-beta.13",
-    "dojo-core": ">=2.0.0-alpha.15",
-    "dojo-dom": ">=2.0.0-alpha.5",
-    "dojo-has": ">=2.0.0-alpha.5",
-    "dojo-loader": ">=2.0.0-beta.7",
-    "dojo-routing": ">=2.0.0-alpha.5",
-    "dojo-shim": ">=2.0.0-beta.2",
-    "dojo-stores": ">=2.0.0-alpha.3",
-    "dojo-widgets": ">=2.0.0-alpha.10",
     "immutable": "^3.8.1",
     "maquette": ">=2.3.7 <=2.4.1",
     "todomvc-app-css": "^2.0.6",

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -42,11 +42,15 @@
     "grunt-text-replace": "^0.4.0",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",
-    "intern": "^3.2.3",
+    "intern": "~3.3.2",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3",
-    "@types/node": "^6.0.46"
+    "@types/node": "^6.0.46",
+    "@types/es6-shim": "~0.31.0",
+    "@types/grunt": "~0.4.0",
+    "@types/glob": "~5.0.0",
+    "@types/chai": "~3.4.0"
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -4,7 +4,6 @@
   "description": "TodoMVC using Dojo2",
   "main": "index.js",
   "scripts": {
-    "prepublish": "grunt peerDepInstall",
     "test": "grunt test"
   },
   "repository": {
@@ -16,24 +15,10 @@
     "node": ">=6",
     "npm": ">=3"
   },
-  "peerDependencies": {
-    "dojo-core": ">=2.0.0-alpha.16",
-    "dojo-app": ">=2.0.0-alpha.8",
-    "dojo-dom": ">=2.0.0-alpha.5",
-    "dojo-actions": ">=2.0.0-alpha.9",
-    "dojo-routing": ">=2.0.0-alpha.5",
-    "dojo-stores": ">=2.0.0-alpha.3",
-    "dojo-widgets": ">=2.0.0-alpha.10",
-    "dojo-compose": ">=2.0.0-beta.13",
-    "dojo-has": ">=2.0.0-alpha.5",
-    "dojo-shim": ">=2.0.0-beta.3",
-    "dojo-interfaces": ">=2.0.0-alpha.4"
-  },
   "devDependencies": {
     "codecov.io": "^0.1.6",
     "dojo-cli-build-webpack": ">=2.0.0-alpha.2",
     "dts-generator": "^1.7.0",
-    "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
@@ -46,14 +31,27 @@
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3",
+    "dojo-interfaces": ">=2.0.0-alpha.4",
     "@types/node": "^6.0.46",
     "@types/es6-shim": "~0.31.0",
     "@types/grunt": "~0.4.0",
     "@types/glob": "~5.0.0",
     "@types/chai": "~3.4.0"
+
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
+    "dojo-actions": ">=2.0.0-alpha.9",
+    "dojo-app": ">=2.0.0-alpha.8",
+    "dojo-compose": ">=2.0.0-beta.13",
+    "dojo-core": ">=2.0.0-alpha.16",
+    "dojo-dom": ">=2.0.0-alpha.5",
+    "dojo-has": ">=2.0.0-alpha.5",
+    "dojo-loader": ">=2.0.0-beta.7",
+    "dojo-routing": ">=2.0.0-alpha.5",
+    "dojo-shim": ">=2.0.0-beta.3",
+    "dojo-stores": ">=2.0.0-alpha.3",
+    "dojo-widgets": ">=2.0.0-alpha.10",
     "immutable": "^3.8.1",
     "maquette": ">=2.3.7 <=2.4.1",
     "todomvc-app-css": "^2.0.6",

--- a/todo-mvc/src/index.ts
+++ b/todo-mvc/src/index.ts
@@ -1,3 +1,6 @@
+import { RootRequire } from 'dojo-interfaces/loader';
+declare const require: RootRequire;
+
 require.config({
 	baseUrl: '../../',
 	packages: [

--- a/todo-mvc/src/index.ts
+++ b/todo-mvc/src/index.ts
@@ -1,7 +1,4 @@
-import { RootRequire } from 'dojo-interfaces/loader';
-declare const require: RootRequire;
-
-require.config({
+(<any> require).config({
 	baseUrl: '../../',
 	packages: [
 		{ name: 'src', location: '_build/src' },
@@ -21,4 +18,4 @@ require.config({
 	]
 });
 
-require([ 'src/main' ], function () {});
+(<any> require)([ 'src/main' ], function () {});

--- a/todo-mvc/tests/functional/Page.ts
+++ b/todo-mvc/tests/functional/Page.ts
@@ -1,4 +1,6 @@
 import * as keys from 'leadfoot/keys';
+import { RootRequire } from 'dojo-interfaces/loader';
+declare const require: RootRequire;
 
 class Selectors {
 	public main = '.main';

--- a/todo-mvc/tests/functional/Page.ts
+++ b/todo-mvc/tests/functional/Page.ts
@@ -1,6 +1,6 @@
 import * as keys from 'leadfoot/keys';
-import { RootRequire } from 'dojo-interfaces/loader';
-declare const require: RootRequire;
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 class Selectors {
 	public main = '.main';

--- a/todo-mvc/typings.json
+++ b/todo-mvc/typings.json
@@ -6,7 +6,6 @@
 		"maquette": "npm:maquette"
 	},
 	"globalDependencies": {
-		"dojo-loader": "npm:dojo-loader",
 		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
@@ -23,7 +22,6 @@
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
 		"jquery": "registry:dt/jquery#1.10.0+20160417213236",
 		"jsdom": "registry:dt/jsdom#2.0.0+20160316155526",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"node": "github:dojo/typings/custom/node/node.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
+		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
 	}
 }

--- a/todo-mvc/typings.json
+++ b/todo-mvc/typings.json
@@ -6,20 +6,14 @@
 		"maquette": "npm:maquette"
 	},
 	"globalDependencies": {
-		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
-	},
-	"devDependencies": {
-		"chai": "registry:npm/chai#3.5.0+20160415060238",
-		"glob": "registry:npm/glob#6.0.0+20160211003958"
 	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
 		"jquery": "registry:dt/jquery#1.10.0+20160417213236",
 		"jsdom": "registry:dt/jsdom#2.0.0+20160316155526",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"


### PR DESCRIPTION
* Converts to `@types` and integrates `dojo-interfaces` into the package;
* Fix additional build issues

Fixes #111 
