### PR TITLE
Moar animations

### DIFF
--- a/monster-cards/src/index.html
+++ b/monster-cards/src/index.html
@@ -4,13 +4,9 @@
 		<meta charset="utf-8">
 		<title>dojo2 Monster Cards</title>
 	</head>
-	<body>
-		<app-projector data-css-transitions="true">
-			<header is="app-widget" data-uid="navbar"></header>
-			<main>
-				<div is="app-widget" data-uid="container"></div>
-			</main>
-		</app-projector>
+	<body is="app-projector" data-css-transitions>
+		<header is="app-widget" data-uid="navbar"></header>
+		<main is="app-widget" data-uid="container"></main>
 	</body>
 </html>
 

--- a/monster-cards/src/main.ts
+++ b/monster-cards/src/main.ts
@@ -11,6 +11,7 @@ import createImage from './widgets/common/createImage';
 import createCardSummary from './widgets/card/createCardSummary';
 import defaultWidgetStore from './stores/widgetStore';
 
+import createCssTransitionMixin from 'dojo-widgets/mixins/createCssTransitionMixin';
 import createWidget from 'dojo-widgets/createWidget';
 
 import 'maquette/src/css-transitions';
@@ -62,7 +63,7 @@ app.loadDefinition({
 		},
 		{
 			id: 'cards',
-			factory: createContainer
+			factory: createContainer.mixin(createCssTransitionMixin)
 		},
 		{
 			id: 'cardsJumbotron',

--- a/monster-cards/src/main.ts
+++ b/monster-cards/src/main.ts
@@ -17,6 +17,7 @@ import createWidget from 'dojo-widgets/createWidget';
 import 'maquette/src/css-transitions';
 
 const app = createApp({ defaultWidgetStore });
+const createAnimatedContainer = createContainer.mixin(createCssTransitionMixin);
 
 app.registerStore('cards-store', cardStore);
 app.loadDefinition({
@@ -41,18 +42,21 @@ app.loadDefinition({
 		},
 		{
 			id: 'container',
-			factory: createContainer
+			factory: createContainer,
+			options: {
+				tagName: 'main'
+			}
 		},
 		{
 			id: 'cardDetails',
-			factory: createContainer,
+			factory: createAnimatedContainer,
 			options: {
 				tagName: 'card-details'
 			}
 		},
 		{
 			id: 'cardDetailsNavbar',
-			factory: createContainer,
+			factory: createAnimatedContainer,
 			options: {
 				tagName: 'card-details-nav-bar'
 			}
@@ -63,7 +67,7 @@ app.loadDefinition({
 		},
 		{
 			id: 'cards',
-			factory: createContainer.mixin(createCssTransitionMixin)
+			factory: createAnimatedContainer
 		},
 		{
 			id: 'cardsJumbotron',
@@ -75,7 +79,7 @@ app.loadDefinition({
 		},
 		{
 			id: 'home',
-			factory: createContainer
+			factory: createAnimatedContainer
 		},
 		{
 			id: 'homeJumbotron',
@@ -87,7 +91,7 @@ app.loadDefinition({
 		},
 		{
 			id: 'gameplay',
-			factory: createContainer
+			factory: createAnimatedContainer
 		},
 		{
 			id: 'gameplayJumbotron',
@@ -102,7 +106,7 @@ app.loadDefinition({
 		},
 		{
 			id: 'about',
-			factory: createContainer
+			factory: createAnimatedContainer
 		},
 		{
 			id: 'aboutJumbotron',

--- a/monster-cards/src/stores/widgetStore.ts
+++ b/monster-cards/src/stores/widgetStore.ts
@@ -12,14 +12,20 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'cardDetails',
+			classes: [ 'animated', 'cardDetails', 'pageHolder' ],
 			children: [
 				'cardDetailsNavbar',
 				'cardDetailsJumbotron'
-			]
+			],
+			enterAnimation: 'fadeInSlideDown',
+			exitAnimation: 'fadeOutSlideUp'
 		},
 		{
 			id: 'cardDetailsNavbar',
-			children: []
+			classes: [ 'animated' ],
+			children: [],
+			enterAnimation: 'slideInDown',
+			exitAnimation: 'slideOutUp'
 		},
 		{
 			id: 'cardDetailsJumbotron',
@@ -27,13 +33,12 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'cards',
-			classes: [ 'animated', 'cards' ],
+			classes: [ 'animated', 'cards', 'pageHolder' ],
 			children: [
 				'cardsJumbotron',
 				'cardsList'
 			],
-			enterAnimation: 'fadeIn',
-			exitAnimation: 'fadeOut'
+			enterAnimation: 'fadeIn'
 		},
 		{
 			id: 'cardsList',
@@ -45,7 +50,9 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'home',
-			children: [ 'homeJumbotron' ]
+			classes: [ 'animated', 'pageHolder' ],
+			children: [ 'homeJumbotron' ],
+			enterAnimation: 'fadeIn'
 		},
 		{
 			id: 'homeJumbotron',
@@ -58,7 +65,9 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'about',
-			children: [ 'aboutJumbotron' ]
+			classes: [ 'animated', 'pageHolder' ],
+			children: [ 'aboutJumbotron' ],
+			enterAnimation: 'fadeIn'
 		},
 		{
 			id: 'aboutJumbotron',
@@ -71,7 +80,9 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'gameplay',
-			children: [ 'gameplayJumbotron' ]
+			classes: [ 'animated', 'pageHolder' ],
+			children: [ 'gameplayJumbotron' ],
+			enterAnimation: 'fadeIn'
 		},
 		{
 			id: 'gameplayJumbotron',

--- a/monster-cards/src/stores/widgetStore.ts
+++ b/monster-cards/src/stores/widgetStore.ts
@@ -27,11 +27,13 @@ export default createMemoryStore<any>({
 		},
 		{
 			id: 'cards',
-			classes: [ 'cards' ],
+			classes: [ 'animated', 'cards' ],
 			children: [
 				'cardsJumbotron',
 				'cardsList'
-			]
+			],
+			enterAnimation: 'fadeIn',
+			exitAnimation: 'fadeOut'
 		},
 		{
 			id: 'cardsList',

--- a/monster-cards/src/variables.styl
+++ b/monster-cards/src/variables.styl
@@ -20,3 +20,7 @@ card-width-large = 192px;
 // input paddings
 input-padding = 4px;
 input-margin = 4px;
+
+// animation durations
+page-animation-duration = 0.5s;
+interaction-animation-duration = 0.5s;

--- a/monster-cards/src/widgets/card-details/card-details.styl
+++ b/monster-cards/src/widgets/card-details/card-details.styl
@@ -1,7 +1,85 @@
 card-details {
-	slide-animation-duration = 0.5s;
 	.cardDetailsDescription {
-		-webkit-animation-duration: slide-animation-duration;
-		animation-duration: slide-animation-duration;
+		-webkit-animation-duration: interaction-animation-duration;
+		animation-duration: interaction-animation-duration;
 	}
+}
+
+
+@-webkit-keyframes fadeInSlideDown {
+	0% {
+		opacity: 0;
+	-webkit-transform: translate3d(0, -68px, 0);
+		transform: translate3d(0, -68px, 0);
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+	-webkit-transform: none;
+		transform: none;
+	}
+}
+
+@keyframes fadeInSlideDown {
+	0% {
+		opacity: 0;
+	-webkit-transform: translate3d(0, -68px, 0);
+		transform: translate3d(0, -68px, 0);
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+	-webkit-transform: none;
+		transform: none;
+	}
+}
+
+.fadeInSlideDown {
+	-webkit-animation-name: fadeInSlideDown;
+	animation-name: fadeInSlideDown;
+}
+
+@-webkit-keyframes fadeOutSlideUp {
+	0% {
+		-webkit-transform: none;
+		transform: none;
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+	opacity: 0;
+	-webkit-transform: translate3d(0, -68px, 0);
+		transform: translate3d(0, -68px, 0);
+	}
+}
+
+@keyframes fadeOutSlideUp {
+	0% {
+		-webkit-transform: none;
+		transform: none;
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+	opacity: 0;
+	-webkit-transform: translate3d(0, -68px, 0);
+		transform: translate3d(0, -68px, 0);
+	}
+}
+
+.fadeOutSlideUp {
+	-webkit-animation-name: fadeOutSlideUp;
+	animation-name: fadeOutSlideUp;
 }

--- a/monster-cards/src/widgets/card-details/card-details.styl
+++ b/monster-cards/src/widgets/card-details/card-details.styl
@@ -9,7 +9,7 @@ card-details {
 @-webkit-keyframes fadeInSlideDown {
 	0% {
 		opacity: 0;
-	-webkit-transform: translate3d(0, -68px, 0);
+		-webkit-transform: translate3d(0, -68px, 0);
 		transform: translate3d(0, -68px, 0);
 	}
 
@@ -18,7 +18,7 @@ card-details {
 	}
 
 	100% {
-	-webkit-transform: none;
+		-webkit-transform: none;
 		transform: none;
 	}
 }
@@ -26,7 +26,7 @@ card-details {
 @keyframes fadeInSlideDown {
 	0% {
 		opacity: 0;
-	-webkit-transform: translate3d(0, -68px, 0);
+		-webkit-transform: translate3d(0, -68px, 0);
 		transform: translate3d(0, -68px, 0);
 	}
 
@@ -35,7 +35,7 @@ card-details {
 	}
 
 	100% {
-	-webkit-transform: none;
+		-webkit-transform: none;
 		transform: none;
 	}
 }
@@ -56,8 +56,8 @@ card-details {
 	}
 
 	100% {
-	opacity: 0;
-	-webkit-transform: translate3d(0, -68px, 0);
+		opacity: 0;
+		-webkit-transform: translate3d(0, -68px, 0);
 		transform: translate3d(0, -68px, 0);
 	}
 }
@@ -73,8 +73,8 @@ card-details {
 	}
 
 	100% {
-	opacity: 0;
-	-webkit-transform: translate3d(0, -68px, 0);
+		opacity: 0;
+		-webkit-transform: translate3d(0, -68px, 0);
 		transform: translate3d(0, -68px, 0);
 	}
 }

--- a/monster-cards/src/widgets/common/general.styl
+++ b/monster-cards/src/widgets/common/general.styl
@@ -10,6 +10,15 @@ main {
 	left: 0;
 	right: 0;
 	position: relative;
+	.pageHolder {
+		-webkit-animation-duration: page-animation-duration;
+		animation-duration: page-animation-duration;
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
 }
 
 .pull-left {

--- a/monster-cards/src/widgets/common/header.styl
+++ b/monster-cards/src/widgets/common/header.styl
@@ -5,6 +5,7 @@ header {
 	position: fixed;
 	left: 0;
 	right: 0;
+	z-index: 50;
 
 	.search {
 		padding: 0 16px;


### PR DESCRIPTION
- animated fade in for each page
- animated slide in / out and fade to card details nav bar
- moved `app-projector` to `body` tag and set tagname to `main` for container widget

![more-animations](https://cloud.githubusercontent.com/assets/814453/20016824/08566444-a2b9-11e6-8a39-51c027b08fce.gif)
