### PR TITLE
No longer use intern AMD plugins in tests

### DIFF
--- a/monster-cards/package.json
+++ b/monster-cards/package.json
@@ -33,6 +33,12 @@
     "maquette": "^2.3.2"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/es6-shim": "~0.31.0",
+    "@types/glob": "~5.0.0",
+    "@types/grunt": "~0.4.0",
+    "@types/node": "^6.0.46",
+    "chai": "^3.5.0",
     "dojo-cli-build-webpack": "^2.0.0-alpha.5",
     "dojo-interfaces": ">=2.0.0-alpha.4",
     "grunt": "^1.0.1",
@@ -40,11 +46,6 @@
     "grunt-dojo2": ">=2.0.0-beta.18",
     "intern": "^3.3.2",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.3",
-    "@types/node": "^6.0.46",
-    "@types/es6-shim": "~0.31.0",
-    "@types/grunt": "~0.4.0",
-    "@types/glob": "~5.0.0",
-    "@types/chai": "~3.4.0"
+    "typescript": "~2.0.3"
   }
 }

--- a/monster-cards/tests/intern.ts
+++ b/monster-cards/tests/intern.ts
@@ -53,6 +53,7 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
+		{ name: 'chai', location: 'node_modules/chai', main: 'chai' },
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
 		{ name: 'dojo-actions', location: 'node_modules/dojo-actions' },
 		{ name: 'dojo-app', location: 'node_modules/dojo-app' },

--- a/monster-cards/tests/unit/main.ts
+++ b/monster-cards/tests/unit/main.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import * as main from '../../src/main';
 
 registerSuite({

--- a/monster-cards/tests/unit/main.ts
+++ b/monster-cards/tests/unit/main.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import * as main from '../../src/main';
 

--- a/monster-cards/tests/unit/widgets/card-details/createCardDescription.ts
+++ b/monster-cards/tests/unit/widgets/card-details/createCardDescription.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import createCardDescription from '../../../../src/widgets/card-details/createCardDescription';
 

--- a/monster-cards/tests/unit/widgets/card-details/createCardDescription.ts
+++ b/monster-cards/tests/unit/widgets/card-details/createCardDescription.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import createCardDescription from '../../../../src/widgets/card-details/createCardDescription';
 
 const state = {

--- a/monster-cards/tests/unit/widgets/card/createCard.ts
+++ b/monster-cards/tests/unit/widgets/card/createCard.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import createCard from '../../../../src/widgets/card/createCard';
 
 const imageClass = 'imageClass';

--- a/monster-cards/tests/unit/widgets/card/createCard.ts
+++ b/monster-cards/tests/unit/widgets/card/createCard.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import createCard from '../../../../src/widgets/card/createCard';
 

--- a/monster-cards/tests/unit/widgets/card/createCardSummary.ts
+++ b/monster-cards/tests/unit/widgets/card/createCardSummary.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import createCardSummary from '../../../../src/widgets/card/createCardSummary';
 
 const state = {

--- a/monster-cards/tests/unit/widgets/card/createCardSummary.ts
+++ b/monster-cards/tests/unit/widgets/card/createCardSummary.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import createCardSummary from '../../../../src/widgets/card/createCardSummary';
 

--- a/monster-cards/tests/unit/widgets/common/createIcon.ts
+++ b/monster-cards/tests/unit/widgets/common/createIcon.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import createIcon from '../../../../src/widgets/common/createIcon';
 
 registerSuite({

--- a/monster-cards/tests/unit/widgets/common/createIcon.ts
+++ b/monster-cards/tests/unit/widgets/common/createIcon.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import createIcon from '../../../../src/widgets/common/createIcon';
 

--- a/monster-cards/tests/unit/widgets/common/createIconLink.ts
+++ b/monster-cards/tests/unit/widgets/common/createIconLink.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import createIconLink from '../../../../src/widgets/common/createIconLink';
 

--- a/monster-cards/tests/unit/widgets/common/createIconLink.ts
+++ b/monster-cards/tests/unit/widgets/common/createIconLink.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import createIconLink from '../../../../src/widgets/common/createIconLink';
 
 registerSuite({

--- a/monster-cards/tests/unit/widgets/common/createIconMenuItem.ts
+++ b/monster-cards/tests/unit/widgets/common/createIconMenuItem.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createIconMenuItem from '../../../../src/widgets/common/createIconMenuItem';

--- a/monster-cards/tests/unit/widgets/common/createIconMenuItem.ts
+++ b/monster-cards/tests/unit/widgets/common/createIconMenuItem.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Promise from 'dojo-shim/Promise';
 import createIconMenuItem from '../../../../src/widgets/common/createIconMenuItem';
 

--- a/monster-cards/tests/unit/widgets/common/createImage.ts
+++ b/monster-cards/tests/unit/widgets/common/createImage.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 
 import createImage from '../../../../src/widgets/common/createImage';

--- a/monster-cards/tests/unit/widgets/common/createImage.ts
+++ b/monster-cards/tests/unit/widgets/common/createImage.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 
 import createImage from '../../../../src/widgets/common/createImage';
 

--- a/monster-cards/tests/unit/widgets/common/createLink.ts
+++ b/monster-cards/tests/unit/widgets/common/createLink.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 
 import createLink from '../../../../src/widgets/common/createLink';
 

--- a/monster-cards/tests/unit/widgets/common/createLink.ts
+++ b/monster-cards/tests/unit/widgets/common/createLink.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 
 import createLink from '../../../../src/widgets/common/createLink';

--- a/monster-cards/tests/unit/widgets/common/createLinkMenuItem.ts
+++ b/monster-cards/tests/unit/widgets/common/createLinkMenuItem.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createLinkMenuItem from '../../../../src/widgets/common/createLinkMenuItem';

--- a/monster-cards/tests/unit/widgets/common/createLinkMenuItem.ts
+++ b/monster-cards/tests/unit/widgets/common/createLinkMenuItem.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Promise from 'dojo-shim/Promise';
 import createLinkMenuItem from '../../../../src/widgets/common/createLinkMenuItem';
 

--- a/monster-cards/tests/unit/widgets/common/createSearchInput.ts
+++ b/monster-cards/tests/unit/widgets/common/createSearchInput.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 

--- a/monster-cards/tests/unit/widgets/common/createSearchInput.ts
+++ b/monster-cards/tests/unit/widgets/common/createSearchInput.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Promise from 'dojo-shim/Promise';
 
 import createSearchInput from './../../../../src/widgets/common/createSearchInput';

--- a/monster-cards/tests/unit/widgets/navbar/createNavActions.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavActions.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Map from 'dojo-shim/Map';
 

--- a/monster-cards/tests/unit/widgets/navbar/createNavActions.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavActions.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Map from 'dojo-shim/Map';
 
 import createNavActions from './../../../../src/widgets/navbar/createNavActions';

--- a/monster-cards/tests/unit/widgets/navbar/createNavMenu.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavMenu.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Map from 'dojo-shim/Map';
 
 import createNavMenu from './../../../../src/widgets/navbar/createNavMenu';

--- a/monster-cards/tests/unit/widgets/navbar/createNavMenu.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavMenu.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Map from 'dojo-shim/Map';
 

--- a/monster-cards/tests/unit/widgets/navbar/createNavbar.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavbar.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Map from 'dojo-shim/Map';
 
 import createNavbar from './../../../../src/widgets/navbar/createNavbar';

--- a/monster-cards/tests/unit/widgets/navbar/createNavbar.ts
+++ b/monster-cards/tests/unit/widgets/navbar/createNavbar.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import Map from 'dojo-shim/Map';
 

--- a/monster-cards/typings.json
+++ b/monster-cards/typings.json
@@ -8,7 +8,7 @@
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
 	}
 }

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -16,19 +16,19 @@
     "npm": ">=3"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/es6-shim": "~0.31.0",
+    "@types/glob": "~5.0.0",
+    "@types/grunt": "~0.4.0",
+    "@types/node": "^6.0.46",
+    "chai": "^3.5.0",
     "dojo-cli-build-webpack": ">=2.0.0-alpha.5",
+    "dojo-interfaces": ">=2.0.0-alpha.4",
     "grunt": "^1.0.1",
     "grunt-dojo2": "^2.0.0-beta.16",
     "intern": "~3.3.2",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.3",
-    "dojo-interfaces": ">=2.0.0-alpha.4",
-    "@types/node": "^6.0.46",
-    "@types/es6-shim": "~0.31.0",
-    "@types/grunt": "~0.4.0",
-    "@types/glob": "~5.0.0",
-    "@types/chai": "~3.4.0"
-
+    "typescript": "~2.0.3"
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",

--- a/todo-mvc/tests/functional/main.ts
+++ b/todo-mvc/tests/functional/main.ts
@@ -1,4 +1,4 @@
-import * as test from 'intern!bdd';
+import * as test from 'intern/lib/interfaces/bdd';
 import * as assert from 'intern/chai!assert';
 import Page from './Page';
 

--- a/todo-mvc/tests/functional/main.ts
+++ b/todo-mvc/tests/functional/main.ts
@@ -1,5 +1,5 @@
 import * as test from 'intern/lib/interfaces/bdd';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import Page from './Page';
 
 test.describe('TodoMVC - Dojo 2', function () {

--- a/todo-mvc/tests/intern.ts
+++ b/todo-mvc/tests/intern.ts
@@ -53,6 +53,7 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
+		{ name: 'chai', location: 'node_modules/chai', main: 'chai' },
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
 		{ name: 'dojo-actions', location: 'node_modules/dojo-actions' },
 		{ name: 'dojo-app', location: 'node_modules/dojo-app' },

--- a/todo-mvc/tests/unit/main.ts
+++ b/todo-mvc/tests/unit/main.ts
@@ -1,5 +1,5 @@
 import * as registerSuite from 'intern/lib/interfaces/object';
-import * as assert from 'intern/chai!assert';
+import { assert } from 'chai';
 import * as main from '../../src/main';
 
 registerSuite({

--- a/todo-mvc/tests/unit/main.ts
+++ b/todo-mvc/tests/unit/main.ts
@@ -1,4 +1,4 @@
-import * as registerSuite from 'intern!object';
+import * as registerSuite from 'intern/lib/interfaces/object';
 import * as assert from 'intern/chai!assert';
 import * as main from '../../src/main';
 

--- a/todo-mvc/typings.json
+++ b/todo-mvc/typings.json
@@ -13,7 +13,7 @@
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
 		"jquery": "registry:dt/jquery#1.10.0+20160417213236",
 		"jsdom": "registry:dt/jsdom#2.0.0+20160316155526",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"


### PR DESCRIPTION
Pre-requisite for https://github.com/dojo/cli/issues/13

* Use the path for intern test interfaces rather than the AMD plugin.
* Switch to using @types/chai for chai rather than the intern plugin.
