### PR TITLE
Fixes todo editing, adds a11y features

### DIFF
--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -14,8 +14,8 @@ interface FormInputEvent extends KeyboardEvent {
 }
 
 export const todoInput = createAction({
-	do({ event: { keyCode, target: { value: label } } }: { event: FormInputEvent }) {
-		if (keyCode === 13 && label) {
+	do({ event: { which, target: { value: label } } }: { event: FormInputEvent }) {
+		if (which === 13 && label) {
 			addTodo.do({ label, completed: false });
 			return widgetStore.patch({ id: 'new-todo', value: '' });
 		}
@@ -32,10 +32,14 @@ function toggleEditing(todos: TodoItemState[], todoId: string, editing: boolean)
 }
 
 export const todoEdit = createAction({
-	do(options: { id: string }) {
+	do(options: { event: KeyboardEvent, state: any }) {
+		const { event, state: { id } } = options;
+		if (event.type === 'keypress' && event.which !== 13 && event.which !== 32) {
+			return;
+		}
 		widgetStore.get('todo-list').then((todoListState: any) => {
 			const { todos } = todoListState;
-			todoListState.todos = toggleEditing(todos, options.id, true);
+			todoListState.todos = toggleEditing(todos, id, true);
 			return widgetStore.patch({ id: 'todo-list', todoListState });
 		});
 	}
@@ -43,11 +47,11 @@ export const todoEdit = createAction({
 
 export const todoEditInput = createAction({
 	do(options: { event: FormInputEvent, state: any }) {
-		const { event: { keyCode } } = options;
-		if (keyCode === 13) {
+		const { event: { which } } = options;
+		if (which === 13) {
 			return todoSave.do(options);
 		}
-		else if (keyCode === 27) {
+		else if (which === 27) {
 			return widgetStore.get('todo-list').then((todoListState: any) => {
 				const { todos } = todoListState;
 				todoListState.todos = toggleEditing(todos, options.state.id, false);

--- a/todo-mvc/src/index.html
+++ b/todo-mvc/src/index.html
@@ -7,7 +7,7 @@
 	<body>
 		<my-app></my-app>
 		<footer class="info">
-			<p>Double-click to edit a todo</p>
+			<p id="edit-instructions">Double-click or press Enter to edit a todo</p>
 			<p>Credits:
 				<a href="https://github.com/matt-gadd">Matt Gadd</a>,
 				<a href="https://github.com/agubler">Anthony Gubler</a>

--- a/todo-mvc/src/main.styl
+++ b/todo-mvc/src/main.styl
@@ -1,1 +1,19 @@
 @import '../node_modules/todomvc-app-css/index.css';
+
+:focus {
+  border: 1px solid red;
+}
+/*
+.todo-list li .destroy {
+  display: block
+  bottom: auto;
+}
+
+.todo-list li .edit {
+  display: block;
+}
+
+.todo-list li.editing .view {
+  display: block;
+}
+*/

--- a/todo-mvc/src/main.styl
+++ b/todo-mvc/src/main.styl
@@ -1,19 +1,1 @@
 @import '../node_modules/todomvc-app-css/index.css';
-
-:focus {
-  border: 1px solid red;
-}
-/*
-.todo-list li .destroy {
-  display: block
-  bottom: auto;
-}
-
-.todo-list li .edit {
-  display: block;
-}
-
-.todo-list li.editing .view {
-  display: block;
-}
-*/

--- a/todo-mvc/src/main.styl
+++ b/todo-mvc/src/main.styl
@@ -1,1 +1,86 @@
 @import '../node_modules/todomvc-app-css/index.css';
+
+/* colors, for reference */
+$red = rgba(175,47,47,.2);
+$lightRed = rgba(175,47,47,.1);
+$textColor = #4d4d4d;
+$textLight = #777777;
+$darkGrey = #999999;
+$lightGrey = #ededed;
+$green = #bddad5;
+
+/* Recommended way to make hidden content accessible to screenreaders */
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+/* Override TodoMVC styles that target all labels in .todo-list li */
+.todo-list li .simple-label {
+  margin: 0;
+  padding: 0;
+}
+
+/* Focus styles */
+.new-todo {
+  border: 1px solid transparent;
+  &:focus {
+    border: 1px solid $darkGrey;
+    box-shadow: inset 0 -1px 5px 0 rgba(0,0,0,.2);
+  }
+}
+
+/* All the repeated inline svgs don't seem ideal, but it maintains consistency with todomvc-app-css */
+@css {
+  .todo-list li .toggle:focus:after {
+    content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/></svg>');
+  }
+  .todo-list li .toggle:checked:focus:after {
+    content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/><path fill="#5dc2af" d="M72 25L42 71 27 56l-4 4 20 20 34-52z"/></svg>');
+  }
+}
+
+.toggle-all:focus:before {
+  color: $green;
+}
+
+.todo-list li label:focus {
+  box-shadow: inset 0 0 0 1px $green;
+}
+
+.todo-list li .destroy {
+  display: block;
+  opacity: 0;
+  transition: all 0.2s ease-out;
+}
+
+.todo-list li:hover .destroy, .todo-list li .destroy:focus {
+  opacity: 1;
+}
+
+.todo-list li .destroy:hover {
+  cursor: pointer;
+}
+
+.filters li a:focus {
+  background-color: $lightRed;
+}
+
+.info a:focus, .clear-completed:focus {
+  text-decoration: underline;
+}
+
+/* Move the border-top from .main to prevent it from showing up before items are added */
+.main {
+  border-top: none;
+}
+
+.todo-list li:first-child {
+  border-top: 1px solid $lightGrey;
+}

--- a/todo-mvc/src/main.styl
+++ b/todo-mvc/src/main.styl
@@ -11,76 +11,76 @@ $green = #bddad5;
 
 /* Recommended way to make hidden content accessible to screenreaders */
 .visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
 }
 
 /* Override TodoMVC styles that target all labels in .todo-list li */
 .todo-list li .simple-label {
-  margin: 0;
-  padding: 0;
+	margin: 0;
+	padding: 0;
 }
 
 /* Focus styles */
 .new-todo {
-  border: 1px solid transparent;
-  &:focus {
-    border: 1px solid $darkGrey;
-    box-shadow: inset 0 -1px 5px 0 rgba(0,0,0,.2);
-  }
+	border: 1px solid transparent;
+	&:focus {
+		border: 1px solid $darkGrey;
+		box-shadow: inset 0 -1px 5px 0 rgba(0,0,0,.2);
+	}
 }
 
 /* All the repeated inline svgs don't seem ideal, but it maintains consistency with todomvc-app-css */
 @css {
-  .todo-list li .toggle:focus:after {
-    content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/></svg>');
-  }
-  .todo-list li .toggle:checked:focus:after {
-    content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/><path fill="#5dc2af" d="M72 25L42 71 27 56l-4 4 20 20 34-52z"/></svg>');
-  }
+	.todo-list li .toggle:focus:after {
+		content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/></svg>');
+	}
+	.todo-list li .toggle:checked:focus:after {
+		content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="-10 -18 100 135"><circle cx="50" cy="50" r="50" fill="#e9f5f3" stroke="#bddad5" stroke-width="3"/><path fill="#5dc2af" d="M72 25L42 71 27 56l-4 4 20 20 34-52z"/></svg>');
+	}
 }
 
 .toggle-all:focus:before {
-  color: $green;
+	color: $green;
 }
 
 .todo-list li label:focus {
-  box-shadow: inset 0 0 0 1px $green;
+	box-shadow: inset 0 0 0 1px $green;
 }
 
 .todo-list li .destroy {
-  display: block;
-  opacity: 0;
-  transition: all 0.2s ease-out;
+	display: block;
+	opacity: 0;
+	transition: all 0.2s ease-out;
 }
 
 .todo-list li:hover .destroy, .todo-list li .destroy:focus {
-  opacity: 1;
+	opacity: 1;
 }
 
 .todo-list li .destroy:hover {
-  cursor: pointer;
+	cursor: pointer;
 }
 
 .filters li a:focus {
-  background-color: $lightRed;
+	background-color: $lightRed;
 }
 
 .info a:focus, .clear-completed:focus {
-  text-decoration: underline;
+	text-decoration: underline;
 }
 
 /* Move the border-top from .main to prevent it from showing up before items are added */
 .main {
-  border-top: none;
+	border-top: none;
 }
 
 .todo-list li:first-child {
-  border-top: 1px solid $lightGrey;
+	border-top: 1px solid $lightGrey;
 }

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -20,7 +20,9 @@ const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInpu
 function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	const focused = instance.state.focused;
 	if (focused) {
-		element.focus();
+		if (focused) {
+			setTimeout(() => element.focus(), 0);
+		}
 	}
 	else if (!focused && document.activeElement === element) {
 		element.blur();

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -20,7 +20,7 @@ const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInpu
 function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	const focused = instance.state.focused;
 	if (focused) {
-		setTimeout(() => element.focus(), 0);
+		element.focus();
 	}
 	else if (!focused && document.activeElement === element) {
 		element.blur();

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -20,9 +20,7 @@ const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInpu
 function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	const focused = instance.state.focused;
 	if (focused) {
-		if (focused) {
-			setTimeout(() => element.focus(), 0);
-		}
+		setTimeout(() => element.focus(), 0);
 	}
 	else if (!focused && document.activeElement === element) {
 		element.blur();

--- a/todo-mvc/src/widgets/createMainSection.ts
+++ b/todo-mvc/src/widgets/createMainSection.ts
@@ -25,8 +25,8 @@ const createMainSection = createWidgetBase.mixin({
 				};
 
 				return [
-					d(createTodoList, { id: 'todo-list', stateFrom }),
-					d(createCheckboxInput, <WidgetOptions<WidgetState> > checkBoxOptions)
+					d(createCheckboxInput, <WidgetOptions<WidgetState> > checkBoxOptions),
+					d(createTodoList, { id: 'todo-list', stateFrom })
 				];
 			}
 		]

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -56,7 +56,7 @@ const createTodoItem = createWidgetBase.mixin({
 						value: label,
 						listeners: {
 							blur: (evt: Event) => { todoSave.do({ state, event }); },
-							keyup: (evt: Event) => { todoEditInput.do({ state, event }); }
+							keypress: (evt: Event) => { todoEditInput.do({ state, event }); }
 						},
 						state: { focused, classes: [ 'edit' ] }
 					};

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -8,6 +8,7 @@ import createFocusableTextInput from './createFocusableTextInput';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { TextInputOptions } from 'dojo-widgets/createTextInput';
+import createTodoLabel from './createTodoLabel';
 
 export type TodoItemState = WidgetState & {
 	label: string;
@@ -25,7 +26,11 @@ const createLabel = createWidgetBase
 		tagName: 'label',
 		nodeAttributes: [
 			function (this: Widget<WidgetState & { label: string }>): VNodeProperties {
-				return { innerHTML: this.state.label };
+				return {
+					innerHTML: this.state.label,
+					'aria-describedby': 'edit-instructions',
+					tabindex: '0'
+				};
 			}
 		]
 	});
@@ -62,7 +67,14 @@ const createTodoItem = createWidgetBase.mixin({
 								state: { classes: [ 'toggle' ], checked }
 							}),
 							d(createLabel, {
-								listeners: { dblclick: () => { todoEdit.do(state); } },
+								listeners: {
+									dblclick: () => { todoEdit.do(state); },
+									keypress: (event: KeyboardEvent) => {
+										if (event.which === 13) {
+											todoEdit.do(state);
+										}
+									}
+								},
 								state: { label }
 							}),
 							d(createButton, {

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -8,7 +8,6 @@ import createFocusableTextInput from './createFocusableTextInput';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { TextInputOptions } from 'dojo-widgets/createTextInput';
-import createTodoLabel from './createTodoLabel';
 
 export type TodoItemState = WidgetState & {
 	label: string;
@@ -68,12 +67,8 @@ const createTodoItem = createWidgetBase.mixin({
 							}),
 							d(createLabel, {
 								listeners: {
-									dblclick: () => { todoEdit.do(state); },
-									keypress: (event: KeyboardEvent) => {
-										if (event.which === 13) {
-											todoEdit.do(state);
-										}
-									}
+									dblclick: (event: Event) => { todoEdit.do({ state, event }); },
+									keypress: (event: KeyboardEvent) => { todoEdit.do({ state, event }); }
 								},
 								state: { label }
 							}),


### PR DESCRIPTION
You can now edit a todo by double-clicking or hitting enter, and it will focus on the todo's text input.