### PR TITLE
Use WidgetBase in Todo-MVC

### DIFF
--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -42,7 +42,7 @@
     "dojo-routing": ">=2.0.0-alpha.5",
     "dojo-shim": ">=2.0.0-beta.3",
     "dojo-stores": ">=2.0.0-alpha.4",
-    "dojo-widgets": ">=2.0.0-alpha.10",
+    "dojo-widgets": ">=2.0.0-alpha.13",
     "immutable": "^3.8.1",
     "maquette": ">=2.3.7 <=2.4.1",
     "todomvc-app-css": "^2.0.6",

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -42,7 +42,7 @@
     "dojo-routing": ">=2.0.0-alpha.5",
     "dojo-shim": ">=2.0.0-beta.3",
     "dojo-stores": ">=2.0.0-alpha.4",
-    "dojo-widgets": "2.0.0-alpha.10",
+    "dojo-widgets": ">=2.0.0-alpha.10",
     "immutable": "^3.8.1",
     "maquette": ">=2.3.7 <=2.4.1",
     "todomvc-app-css": "^2.0.6",

--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -3,6 +3,7 @@ import { assign } from 'dojo-core/lang';
 import { Item } from '../stores/todoStore';
 import widgetStore from '../stores/widgetStore';
 import { addTodo, deleteCompleted, deleteTodo, toggleAll, updateTodo } from './todoStoreActions';
+import { TodoItemState } from '../widgets/createTodoItem';
 
 interface FormEvent extends Event {
 	target: HTMLInputElement;
@@ -21,10 +22,13 @@ export const todoInput = createAction({
 	}
 });
 
-function toggleEditing(todos: any[], todoId: string, editing: boolean): any[] {
+function toggleEditing(todos: TodoItemState[], todoId: string, editing: boolean): TodoItemState[] {
 	return todos
-		.filter((todo: any) => todo.id === todoId)
-		.map((todo: any) => todo.editing = true);
+		.filter((todo) => todo.id === todoId)
+		.map((todo) => {
+			todo.editing = true;
+			return todo;
+		});
 }
 
 export const todoEdit = createAction({

--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -1,15 +1,8 @@
 import createAction from 'dojo-actions/createAction';
 import { assign } from 'dojo-core/lang';
-
 import { Item } from '../stores/todoStore';
 import widgetStore from '../stores/widgetStore';
-import {
-	addTodo,
-	deleteCompleted,
-	deleteTodo,
-	toggleAll,
-	updateTodo
-} from './todoStoreActions';
+import { addTodo, deleteCompleted, deleteTodo, toggleAll, updateTodo } from './todoStoreActions';
 
 interface FormEvent extends Event {
 	target: HTMLInputElement;
@@ -35,7 +28,13 @@ export const todoInput = createAction({
 
 export const todoEdit = createAction({
 	do(options: any) {
-		return widgetStore.patch(assign(options, { editing: true }));
+		widgetStore.get('todo-list').then((todoList: any) => {
+			const { todos } = todoList;
+			todos
+				.filter((todo: any) => todo.id === options.id)
+				.forEach((todo: any) => todo.editing = true);
+			return widgetStore.patch('todo-list', todoList);
+		});
 	}
 });
 

--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -40,7 +40,13 @@ export const todoEditInput = createAction({
 			return todoSave.do(options);
 		}
 		else if (keyCode === 27) {
-			return widgetStore.patch(assign(options.state, { editing: false }));
+			return widgetStore.get('todo-list').then((todoListState: any) => {
+				const { todos } = todoListState;
+				todos
+				.filter((todo: any) => todo.id === options.state.id)
+				.forEach((todo: any) => todo.editing = false);
+				return widgetStore.patch('todo-list', todoListState);
+			});
 		}
 	}
 });

--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -21,14 +21,17 @@ export const todoInput = createAction({
 	}
 });
 
+function toggleEditing(todos: any[], todoId: string, editing: boolean): any[] {
+	return todos
+		.filter((todo: any) => todo.id === todoId)
+		.map((todo: any) => todo.editing = true);
+}
+
 export const todoEdit = createAction({
 	do(options: any) {
 		widgetStore.get('todo-list').then((todoListState: any) => {
 			const { todos } = todoListState;
-			todos
-				.filter((todo: any) => todo.id === options.id)
-				.forEach((todo: any) => todo.editing = true);
-			return widgetStore.patch('todo-list', todoListState);
+			return widgetStore.patch('todo-list', toggleEditing(todos, options.id, true));
 		});
 	}
 });
@@ -42,10 +45,7 @@ export const todoEditInput = createAction({
 		else if (keyCode === 27) {
 			return widgetStore.get('todo-list').then((todoListState: any) => {
 				const { todos } = todoListState;
-				todos
-				.filter((todo: any) => todo.id === options.state.id)
-				.forEach((todo: any) => todo.editing = false);
-				return widgetStore.patch('todo-list', todoListState);
+				return widgetStore.patch('todo-list', toggleEditing(todos, options.state.id, false));
 			});
 		}
 	}
@@ -85,11 +85,7 @@ export const filter = createAction({
 });
 
 export const todoToggleAll = createAction({
-	do({
-		event: {
-			target: { checked }
-		}
-	}: { event: FormEvent }) {
+	do({ event: { target: { checked } } }: { event: FormEvent }) {
 		toggleAll.do({ checked });
 	}
 });

--- a/todo-mvc/src/actions/userActions.ts
+++ b/todo-mvc/src/actions/userActions.ts
@@ -13,12 +13,7 @@ interface FormInputEvent extends KeyboardEvent {
 }
 
 export const todoInput = createAction({
-	do({
-		event: {
-			keyCode,
-			target: { value: label }
-		}
-	}: { event: FormInputEvent }) {
+	do({ event: { keyCode, target: { value: label } } }: { event: FormInputEvent }) {
 		if (keyCode === 13 && label) {
 			addTodo.do({ label, completed: false });
 			return widgetStore.patch({ id: 'new-todo', value: '' });
@@ -28,12 +23,12 @@ export const todoInput = createAction({
 
 export const todoEdit = createAction({
 	do(options: any) {
-		widgetStore.get('todo-list').then((todoList: any) => {
-			const { todos } = todoList;
+		widgetStore.get('todo-list').then((todoListState: any) => {
+			const { todos } = todoListState;
 			todos
 				.filter((todo: any) => todo.id === options.id)
 				.forEach((todo: any) => todo.editing = true);
-			return widgetStore.patch('todo-list', todoList);
+			return widgetStore.patch('todo-list', todoListState);
 		});
 	}
 });
@@ -51,12 +46,7 @@ export const todoEditInput = createAction({
 });
 
 export const todoSave = createAction({
-	do({
-		event: {
-			target: { value: label }
-		},
-		state
-	}: { event: FormInputEvent, state: any }) {
+	do({ event: { target: { value: label } }, state }: { event: FormInputEvent, state: any }) {
 		if (!label) {
 			return deleteTodo.do(state);
 		}

--- a/todo-mvc/src/actions/widgetStoreActions.ts
+++ b/todo-mvc/src/actions/widgetStoreActions.ts
@@ -1,6 +1,4 @@
 import createAction from 'dojo-actions/createAction';
-import { assign } from 'dojo-core/lang';
-import { includes } from 'dojo-shim/array';
 
 import { ChangeRecord } from '../stores/todoStore';
 import widgetStore from '../stores/widgetStore';
@@ -29,36 +27,8 @@ export const updateHeaderAndFooter = createAction({
 	}
 });
 
-export const deleteTodo = createAction({
-	do({ afterAll, deletes }: ChangeRecord) {
-		if (deletes.length) {
-			const [ deletedId ] = deletes;
-			const children = afterAll
-				.filter(({ id }) => id !== deletedId)
-				.map(({ id }) => id);
-
-			return widgetStore
-				.delete(deletedId)
-				.patch({ id: 'todo-list', children });
-		}
-	}
-});
-
 export const putTodo = createAction({
-	do({ beforeAll, puts }: ChangeRecord) {
-		if (puts.length) {
-			const [ item ] = puts;
-			const children = beforeAll.map(({ id }) => id);
-
-			if (includes(children, item.id)) {
-				return widgetStore
-					.patch(item)
-					.patch({ id: 'todo-list', children });
-			}
-
-			return widgetStore
-				.put(assign({}, <any> item, { type: 'todo-item' }))
-				.patch({id: 'todo-list', children: [...children, item.id]});
-		}
+	do({ afterAll }: ChangeRecord) {
+		return widgetStore.patch({ id: 'todo-list', todos: afterAll });
 	}
 });

--- a/todo-mvc/src/index.html
+++ b/todo-mvc/src/index.html
@@ -8,7 +8,7 @@
 		<section class="todoapp">
 			<header>
 				<app-projector>
-					<dojo-widget data-uid="title" data-options='{"tagName": "h1"}'></dojo-widget>
+					<todo-title data-uid="title"></todo-title>
 					<div is="app-widget" id="new-todo"/>
 				</app-projector>
 			</header>

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -11,13 +11,14 @@ import createTodoFooter from './widgets/createTodoFooter';
 import createTodoItem from './widgets/createTodoItem';
 import createTodoList from './widgets/createTodoList';
 import { Widget, WidgetState } from 'dojo-interfaces/widgetBases';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
 
 const app = createApp({ defaultWidgetStore: widgetStore });
 
 const createTitle = createWidgetBase.extend({
 	tagName: 'h1',
 	nodeAttributes: [
-		function (this: Widget<WidgetState & { label: string }>): any {
+		function (this: Widget<WidgetState & { label: string }>): VNodeProperties {
 			return { innerHTML: this.state.label };
 		}
 	]

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,8 +1,6 @@
 import createApp from 'dojo-app/createApp';
-import global from 'dojo-core/global';
-import ShimPromise from 'dojo-shim/Promise';
 import createPanel from 'dojo-widgets/createPanel';
-import createWidget from 'dojo-widgets/createWidget';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 
 import { todoToggleAll, todoInput } from './actions/userActions';
 import router from './routes';
@@ -15,6 +13,15 @@ import createTodoItem from './widgets/createTodoItem';
 import createTodoList from './widgets/createTodoList';
 
 const app = createApp({ defaultWidgetStore: widgetStore });
+
+const createTitle = createWidgetBase.extend({
+	tagName: 'h1',
+	nodeAttributes: [
+		function (this: any): any {
+			return { innerHTML: this.state.label };
+		}
+	]
+});
 
 app.registerStore('todo-store', todoStore);
 app.loadDefinition({
@@ -52,7 +59,7 @@ app.loadDefinition({
 	customElements: [
 		{
 			name: 'dojo-widget',
-			factory: createWidget
+			factory: createTitle
 		},
 		{
 			name: 'todo-item',
@@ -60,9 +67,6 @@ app.loadDefinition({
 		}
 	]
 });
-
-// Try to use the native promise so the browser can report unhandled rejections.
-const { /* tslint:disable */Promise/* tslint:enable */ = ShimPromise } = global;
 Promise.resolve(app.realize(document.body))
 	.then(() => bindTodoStoreActions())
 	.then(() => router.start());

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,7 +1,6 @@
 import createApp from 'dojo-app/createApp';
 import createPanel from 'dojo-widgets/createPanel';
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
-
 import { todoToggleAll, todoInput } from './actions/userActions';
 import router from './routes';
 import todoStore, { bindActions as bindTodoStoreActions } from './stores/todoStore';
@@ -11,13 +10,14 @@ import createFocusableTextInput from './widgets/createFocusableTextInput';
 import createTodoFooter from './widgets/createTodoFooter';
 import createTodoItem from './widgets/createTodoItem';
 import createTodoList from './widgets/createTodoList';
+import { Widget, WidgetState } from 'dojo-interfaces/widgetBases';
 
 const app = createApp({ defaultWidgetStore: widgetStore });
 
 const createTitle = createWidgetBase.extend({
 	tagName: 'h1',
 	nodeAttributes: [
-		function (this: any): any {
+		function (this: Widget<WidgetState & { label: string }>): any {
 			return { innerHTML: this.state.label };
 		}
 	]

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -59,7 +59,7 @@ app.loadDefinition({
 	],
 	customElements: [
 		{
-			name: 'dojo-widget',
+			name: 'todo-title',
 			factory: createTitle
 		},
 		{

--- a/todo-mvc/src/stores/todoStore.ts
+++ b/todo-mvc/src/stores/todoStore.ts
@@ -1,6 +1,6 @@
 import createMemoryStore, { MemoryStore } from 'dojo-stores/createMemoryStore';
 
-import { updateHeaderAndFooter, deleteTodo, putTodo } from '../actions/widgetStoreActions';
+import { updateHeaderAndFooter, putTodo } from '../actions/widgetStoreActions';
 
 export interface Item {
 	id: string;
@@ -31,13 +31,6 @@ export function bindActions() {
 		.subscribe((options: any) => {
 			const changeRecord = <ChangeRecord> options;
 			updateHeaderAndFooter.do(changeRecord);
-
-			const { puts, deletes } = changeRecord;
-			if (deletes.length) {
-				deleteTodo.do(changeRecord);
-			}
-			if (puts.length) {
-				putTodo.do(changeRecord);
-			}
+			putTodo.do(changeRecord);
 		});
 }

--- a/todo-mvc/src/widgets/createCheckboxInput.ts
+++ b/todo-mvc/src/widgets/createCheckboxInput.ts
@@ -2,7 +2,7 @@ import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
-import { VNodeProperties } from 'maquette';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
 
 export type CheckboxInputState = WidgetState & FormFieldMixinState<string> & {
 	checked?: boolean;

--- a/todo-mvc/src/widgets/createCheckboxInput.ts
+++ b/todo-mvc/src/widgets/createCheckboxInput.ts
@@ -1,27 +1,23 @@
-import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
-import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
+import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'maquette';
 
-/* I suspect this needs to go somewhere else */
-export interface TypedTargetEvent<T extends EventTarget> extends Event {
-	target: T;
-}
-
-export type CheckboxInputState = RenderMixinState & FormFieldMixinState<string> & {
+export type CheckboxInputState = WidgetState & FormFieldMixinState<string> & {
 	checked?: boolean;
 };
 
-export type CheckboxInputOptions = RenderMixinOptions<CheckboxInputState> & FormFieldMixinOptions<string, CheckboxInputState>;
+export type CheckboxInputOptions = WidgetOptions<CheckboxInputState> & FormFieldMixinOptions<string, CheckboxInputState>;
 
-export type CheckboxInput = RenderMixin<CheckboxInputState> & FormFieldMixin<string, CheckboxInputState> & VNodeEvented;
+export type CheckboxInput = Widget<CheckboxInputState> & FormFieldMixin<string, CheckboxInputState>;
 
-const createCheckboxInput = createRenderMixin
+const createCheckboxInput = createWidgetBase
 	.mixin(createFormFieldMixin)
 	.mixin({
 		mixin: createVNodeEvented,
 		initialize(instance) {
-			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
+			instance.own(instance.on('input', (event: any) => {
 				instance.value = event.target.value;
 			}));
 		}

--- a/todo-mvc/src/widgets/createCheckboxInput.ts
+++ b/todo-mvc/src/widgets/createCheckboxInput.ts
@@ -3,6 +3,7 @@ import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases'
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
+import { EventTargettedObject } from 'dojo-interfaces/core';
 
 export type CheckboxInputState = WidgetState & FormFieldMixinState<string> & {
 	checked?: boolean;
@@ -17,7 +18,7 @@ const createCheckboxInput = createWidgetBase
 	.mixin({
 		mixin: createVNodeEvented,
 		initialize(instance) {
-			instance.own(instance.on('input', (event: any) => {
+			instance.own(instance.on('input', (event: EventTargettedObject<HTMLInputElement>) => {
 				instance.value = event.target.value;
 			}));
 		}

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -4,6 +4,7 @@ import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
+import { EventTargettedObject } from 'dojo-interfaces/core';
 
 export type FocusableTextInputState = WidgetState & FormFieldMixinState<string> & {
 	focused?: boolean;
@@ -31,7 +32,7 @@ const createFocusableTextInput = createWidgetBase
 	.mixin({
 		mixin: createVNodeEvented,
 		initialize(instance) {
-			instance.own(instance.on('input', (event: any) => {
+			instance.own(instance.on('input', (event: EventTargettedObject<HTMLInputElement>) => {
 				instance.value = event.target.value;
 			}));
 			afterUpdateFunctions.set(instance, (element: HTMLInputElement) => afterUpdate(instance, element));

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -3,7 +3,7 @@ import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldM
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
-import { VNodeProperties } from 'maquette';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
 
 export type FocusableTextInputState = WidgetState & FormFieldMixinState<string> & {
 	focused?: boolean;
@@ -17,7 +17,7 @@ export type FocusableTextInput = Widget<FocusableTextInputState> & FormFieldMixi
 const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInputElement): void}>();
 
 function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
-	const focused: boolean = instance.state.focused;
+	const focused = instance.state.focused;
 	if (focused) {
 		setTimeout(() => element.focus(), 0);
 	}
@@ -41,8 +41,14 @@ const createFocusableTextInput = createWidgetBase
 		nodeAttributes: [
 			function (this: FocusableTextInput): VNodeProperties {
 				const afterUpdate = afterUpdateFunctions.get(this);
-				const { placeholder } = this.state;
-				return { afterUpdate, placeholder };
+				const { placeholder, initialValue, value } = this.state;
+				const hasValue = ({}).hasOwnProperty.call(this.state, 'value');
+				return {
+					afterUpdate,
+					placeholder,
+					afterCreate: afterUpdate,
+					value: hasValue ? value : initialValue
+				};
 			}
 		],
 

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -1,22 +1,18 @@
 import WeakMap from 'dojo-shim/WeakMap';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinOptions, FormFieldMixinState } from 'dojo-widgets/mixins/createFormFieldMixin';
-import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
-import createVNodeEvented, { VNodeEvented } from 'dojo-widgets/mixins/createVNodeEvented';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState } from 'dojo-interfaces/widgetBases';
+import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 import { VNodeProperties } from 'maquette';
 
-/* I suspect this needs to go somewhere else */
-export interface TypedTargetEvent<T extends EventTarget> extends Event {
-	target: T;
-}
-
-export type FocusableTextInputState = RenderMixinState & FormFieldMixinState<string> & {
+export type FocusableTextInputState = WidgetState & FormFieldMixinState<string> & {
 	focused?: boolean;
 	placeholder?: string;
 };
 
-export type FocusableTextInputOptions = RenderMixinOptions<FocusableTextInputState> & FormFieldMixinOptions<string, FocusableTextInputState>;
+export type FocusableTextInputOptions = WidgetOptions<FocusableTextInputState> & FormFieldMixinOptions<string, FocusableTextInputState>;
 
-export type FocusableTextInput = RenderMixin<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState> & VNodeEvented;
+export type FocusableTextInput = Widget<FocusableTextInputState> & FormFieldMixin<string, FocusableTextInputState>;
 
 const afterUpdateFunctions = new WeakMap<FocusableTextInput, {(element: HTMLInputElement): void}>();
 
@@ -30,12 +26,12 @@ function afterUpdate(instance: FocusableTextInput, element: HTMLInputElement) {
 	}
 }
 
-const createFocusableTextInput = createRenderMixin
+const createFocusableTextInput = createWidgetBase
 	.mixin(createFormFieldMixin)
 	.mixin({
 		mixin: createVNodeEvented,
 		initialize(instance) {
-			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
+			instance.own(instance.on('input', (event: any) => {
 				instance.value = event.target.value;
 			}));
 			afterUpdateFunctions.set(instance, (element: HTMLInputElement) => afterUpdate(instance, element));

--- a/todo-mvc/src/widgets/createFocusableTextInput.ts
+++ b/todo-mvc/src/widgets/createFocusableTextInput.ts
@@ -42,13 +42,12 @@ const createFocusableTextInput = createWidgetBase
 		nodeAttributes: [
 			function (this: FocusableTextInput): VNodeProperties {
 				const afterUpdate = afterUpdateFunctions.get(this);
-				const { placeholder, initialValue, value } = this.state;
-				const hasValue = ({}).hasOwnProperty.call(this.state, 'value');
+				const { placeholder, value } = this.state;
 				return {
 					afterUpdate,
 					placeholder,
-					afterCreate: afterUpdate,
-					value: hasValue ? value : initialValue
+					value,
+					afterCreate: afterUpdate
 				};
 			}
 		],

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -1,50 +1,53 @@
-import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
-import { h, VNode } from 'maquette';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
+import d from 'dojo-widgets/util/d';
 
-type TodoFilterState = RenderMixinState & {
+type TodoFilterState = WidgetState & {
 	activeFilter?: string;
 };
 
-type TodoFilterOptions = RenderMixinOptions<TodoFilterState>;
+type TodoFilterOptions = WidgetOptions<TodoFilterState>;
 
-type TodoFilter = RenderMixin<TodoFilterState>;
+type TodoFilter = Widget<TodoFilterState>;
 
-const createTodoFilter = createRenderMixin
+const createTodoFilter = createWidgetBase
 	.extend({
-		getChildrenNodes(this: TodoFilter): VNode[] {
-			const { activeFilter } = this.state;
-			return [
-				h('li', {}, [
-					h('a', {
-						innerHTML: 'All',
-						href: '#all',
-						classes: {
-							selected: activeFilter === 'all'
-						}
-					})
-				]),
-				h('li', {}, [
-					h('a', {
-						innerHTML: 'Active',
-						href: '#active',
-						classes: {
-							selected: activeFilter === 'active'
-						}
-					})
-				]),
-				h('li', {}, [
-					h('a', {
-						innerHTML: 'Completed',
-						href: '#completed',
-						classes: {
-							selected: activeFilter === 'completed'
-						}
-					})
-				])
-			];
-		},
+		childNodeRenderers: [
+			function(this: TodoFilter): DNode[] {
+				const { activeFilter } = this.state;
+				return [
+					d('li', {}, [
+						d('a', {
+							innerHTML: 'All',
+							href: '#all',
+							classes: {
+								selected: activeFilter === 'all'
+							}
+						})
+					]),
+					d('li', {}, [
+						d('a', {
+							innerHTML: 'Active',
+							href: '#active',
+							classes: {
+								selected: activeFilter === 'active'
+							}
+						})
+					]),
+					d('li', {}, [
+						d('a', {
+							innerHTML: 'Completed',
+							href: '#completed',
+							classes: {
+								selected: activeFilter === 'completed'
+							}
+						})
+					])
+				];
+			}
+		],
 
-		tagName: 'ul'
+		tagName: 'ul.filters'
 	});
 
 export default createTodoFilter;

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -10,40 +10,28 @@ type TodoFilterOptions = WidgetOptions<TodoFilterState>;
 
 type TodoFilter = Widget<TodoFilterState>;
 
+function createFilterItems(activeFilter: string): DNode[] {
+	const filters = [ 'all', 'active', 'completed' ];
+	return filters.map((filterItem) => {
+		const label = filterItem[0].toUpperCase() + filterItem.substring(1);
+		return d('li', {}, [
+			d('a', {
+				innerHTML: label,
+				href: `#${filterItem}`,
+				classes: {
+					selected: activeFilter === filterItem
+				}
+			})
+		]);
+	});
+}
+
 const createTodoFilter = createWidgetBase
 	.extend({
 		childNodeRenderers: [
 			function(this: TodoFilter): DNode[] {
 				const { activeFilter } = this.state;
-				return [
-					d('li', {}, [
-						d('a', {
-							innerHTML: 'All',
-							href: '#all',
-							classes: {
-								selected: activeFilter === 'all'
-							}
-						})
-					]),
-					d('li', {}, [
-						d('a', {
-							innerHTML: 'Active',
-							href: '#active',
-							classes: {
-								selected: activeFilter === 'active'
-							}
-						})
-					]),
-					d('li', {}, [
-						d('a', {
-							innerHTML: 'Completed',
-							href: '#completed',
-							classes: {
-								selected: activeFilter === 'completed'
-							}
-						})
-					])
-				];
+				return createFilterItems(activeFilter);
 			}
 		],
 

--- a/todo-mvc/src/widgets/createTodoFilter.ts
+++ b/todo-mvc/src/widgets/createTodoFilter.ts
@@ -35,7 +35,8 @@ const createTodoFilter = createWidgetBase
 			}
 		],
 
-		tagName: 'ul.filters'
+		tagName: 'ul',
+		classes: [ 'filters' ]
 	});
 
 export default createTodoFilter;

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -19,7 +19,7 @@ const createTodoFooter = createWidgetBase
 	.extend({
 		childNodeRenderers: [
 			function(this: TodoFooter): DNode[] {
-				const { activeCount, completedCount } = this.state;
+				const { activeCount, activeFilter, completedCount } = this.state;
 				const countLabel = activeCount === 1 ? 'item' : 'items';
 
 				return [
@@ -28,7 +28,10 @@ const createTodoFooter = createWidgetBase
 						d('span', [countLabel + ' left'])
 					]),
 					d(createTodoFilter, {
-						state: { classes: [ 'filters' ] }
+						state: {
+							classes: [ 'filters' ],
+							activeFilter
+						}
 					}),
 					completedCount ? d(createButton, {
 						listeners: {

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -1,81 +1,37 @@
-import createButton from 'dojo-widgets/createButton';
-import createParentMapMixin, { ParentMap, ParentMapMixinOptions } from 'dojo-widgets/mixins/createParentMapMixin';
-import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
-
-import { h, VNode } from 'maquette';
-
-import { clearCompleted } from '../actions/userActions';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
+import d from 'dojo-widgets/util/d';
+/*import { clearCompleted } from '../actions/userActions';*/
 import createTodoFilter from './createTodoFilter';
+import createButton from 'dojo-widgets/createButton';
 
-export type TodoFooterState = RenderMixinState & StatefulChildrenState & {
+export type TodoFooterState = WidgetState & {
 	activeFilter?: string;
 	activeCount?: number;
 	completedCount?: number;
 };
 
-export type TodoFooterOptions = RenderMixinOptions<TodoFooterState> & ParentMapMixinOptions<Child> & StatefulChildrenOptions<Child, TodoFooterState>;
+export type TodoFooterOptions = WidgetOptions<TodoFooterState>;
 
-export type TodoFooter = RenderMixin<TodoFooterState> & ParentMap<RenderMixin<TodoFooterState>>;
+export type TodoFooter = Widget<TodoFooterState>;
 
-function manageChildren(this: TodoFooter) {
-	const filterWidget = this.children.get('filter');
-	const buttonWidget = this.children.get('button');
-
-	filterWidget.setState({
-		activeFilter: this.state.activeFilter
-	});
-
-	const clearCompletedButtonClasses = ['clear-completed'];
-	if (this.state.completedCount === 0) {
-		clearCompletedButtonClasses.push('hidden');
-	}
-
-	buttonWidget.setState({
-		classes: clearCompletedButtonClasses
-	});
-}
-
-const createTodoFooter = createRenderMixin
-	.mixin(createStatefulChildrenMixin)
-	.mixin({
-		mixin: createParentMapMixin,
-		initialize(instance, options) {
-			const filterWidget = createTodoFilter({
-				state: {
-					id: 'filter',
-					classes: ['filters']
-				}
-			});
-			const clearCompletedButton = createButton({
-				state: {
-					id: 'button',
-					label: 'Clear completed',
-					classes: ['clear-completed']
-				},
-				listeners: {
-					click: clearCompleted
-				}
-			});
-			instance.append([filterWidget, clearCompletedButton]);
-			instance.on('statechange', manageChildren);
-		}
-	})
+const createTodoFooter = createWidgetBase
 	.extend({
-		getChildrenNodes(this: TodoFooter): VNode[] {
-			const activeCount = this.state.activeCount;
-			const countLabel = activeCount === 1 ? 'item' : 'items';
+		childNodeRenderers: [
+			function(this: TodoFooter): DNode[] {
+				const activeCount = this.state.activeCount;
+				const countLabel = activeCount === 1 ? 'item' : 'items';
 
-			return [
-				h('span', {'class': 'todo-count'}, [
-					h('strong', [activeCount + ' ']),
-					h('span', [countLabel + ' left'])
-				]),
-				this.children.get('filter').render(),
-				this.children.get('button').render()
-			];
-		},
+				return [
+					d('span', {'class': 'todo-count'}, [
+						d('strong', [activeCount + ' ']),
+						d('span', [countLabel + ' left'])
+					]),
+					d(createTodoFilter, { classes: [ 'filters' ] }),
+					d(createButton, { classes: [ 'clear-completed' ] })
+				];
+			}
+		],
 
 		tagName: 'footer'
 	});

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -23,7 +23,7 @@ const createTodoFooter = createWidgetBase
 				const countLabel = activeCount === 1 ? 'item' : 'items';
 
 				return [
-					d('span', {'class': 'todo-count'}, [
+					d('span', { 'class': 'todo-count' }, [
 						d('strong', [activeCount + ' ']),
 						d('span', [countLabel + ' left'])
 					]),

--- a/todo-mvc/src/widgets/createTodoFooter.ts
+++ b/todo-mvc/src/widgets/createTodoFooter.ts
@@ -1,7 +1,7 @@
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
 import d from 'dojo-widgets/util/d';
-/*import { clearCompleted } from '../actions/userActions';*/
+import { clearCompleted } from '../actions/userActions';
 import createTodoFilter from './createTodoFilter';
 import createButton from 'dojo-widgets/createButton';
 
@@ -19,7 +19,7 @@ const createTodoFooter = createWidgetBase
 	.extend({
 		childNodeRenderers: [
 			function(this: TodoFooter): DNode[] {
-				const activeCount = this.state.activeCount;
+				const { activeCount, completedCount } = this.state;
 				const countLabel = activeCount === 1 ? 'item' : 'items';
 
 				return [
@@ -27,8 +27,18 @@ const createTodoFooter = createWidgetBase
 						d('strong', [activeCount + ' ']),
 						d('span', [countLabel + ' left'])
 					]),
-					d(createTodoFilter, { classes: [ 'filters' ] }),
-					d(createButton, { classes: [ 'clear-completed' ] })
+					d(createTodoFilter, {
+						state: { classes: [ 'filters' ] }
+					}),
+					completedCount ? d(createButton, {
+						listeners: {
+							click: clearCompleted
+						},
+						state: {
+							label: 'Clear completed',
+							classes: [ 'clear-completed' ]
+						}
+					}) : null
 				];
 			}
 		],

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -1,166 +1,72 @@
-import WeakMap from 'dojo-shim/WeakMap';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
+import d from 'dojo-widgets/util/d';
+import { todoEdit, todoEditInput, todoRemove, todoSave, todoToggleComplete } from '../actions/userActions';
 import createButton from 'dojo-widgets/createButton';
-import createRenderMixin, { RenderMixin, RenderMixinState, RenderMixinOptions } from 'dojo-widgets/mixins/createRenderMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions, CreateChildrenResults, CreateChildrenResultsItem } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
-import { Child } from 'dojo-widgets/mixins/interfaces';
-
-import { h, VNode } from 'maquette';
-
-import {
-	todoEdit,
-	todoEditInput,
-	todoRemove,
-	todoSave,
-	todoToggleComplete
-} from '../actions/userActions';
 import createCheckboxInput from './createCheckboxInput';
 import createFocusableTextInput from './createFocusableTextInput';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
 
-type TodoItemState = RenderMixinState & StatefulChildrenState & {
+export type TodoItemState = WidgetState & {
+	label: string;
 	editing?: boolean;
 	completed?: boolean;
 };
 
-export type TodoItemOptions = RenderMixinOptions<TodoItemState> & StatefulChildrenOptions<Child, TodoItemState>;
+export type TodoItemOptions = WidgetOptions<TodoItemState>;
 
-export type TodoItem = RenderMixin<TodoItemState>;
+export type TodoItem = Widget<TodoItemState>;
 
-interface TodoItemChildren<C extends Child> extends CreateChildrenResults<C> {
-	label: CreateChildrenResultsItem<C>;
-	checkbox: CreateChildrenResultsItem<C>;
-	editInput: CreateChildrenResultsItem<C>;
-	button: CreateChildrenResultsItem<C>;
-}
-
-/**
- * Internal map of sub children IDs
- */
-const childrenMap = new WeakMap<TodoItem, TodoItemChildren<RenderMixin<any>>>();
-
-/**
- * Internal function to manage the children widgets
- */
-function manageChildren(this: TodoItem) {
-	/* Obtain references to children widgets */
-	const { checkbox, label, editInput } = childrenMap.get(this);
-
-	/* Adjust the state of the children to reflect parent */
-
-	label.widget.setState({
-		label: this.state.label
-	});
-
-	editInput.widget.setState({
-		value: this.state.label,
-		focused: this.state.editing
-	});
-
-	checkbox.widget.setState({
-		checked: this.state.completed
-	});
-}
-
-const createTodoItem = createRenderMixin
-	.mixin({
-		mixin: createStatefulChildrenMixin,
-		initialize(instance, options) {
-			let destroyed = false;
-			instance.own({
-				destroy() {
-					destroyed = true;
-				}
-			});
-
-			return instance.createChildren({
-				checkbox: {
-					factory: createCheckboxInput,
-					options: {
-						state: {
-							classes: [ 'toggle' ]
-						},
-						listeners: {
-							change: () => { todoToggleComplete.do(instance.state); }
-						}
-					}
-				},
-				button: {
-					factory: createButton,
-					options: {
-						state: {
-							classes: [ 'destroy' ]
-						},
-						listeners: {
-							click: () => { todoRemove.do(instance.state); }
-						}
-					}
-				},
-				label: {
-					factory: createRenderMixin,
-					options: {
-						listeners: {
-							dblclick: () => { todoEdit.do(instance.state); }
-						},
-						tagName: 'label'
-					}
-				},
-				editInput: {
-					factory: createFocusableTextInput,
-					options: {
-						state: {
-							classes: [ 'edit' ]
-						},
-						listeners: {
-							blur: (event: Event) => { todoSave.do({state: instance.state, event}); },
-							keyup: (event: Event) => { todoEditInput.do({state: instance.state, event}); }
-						}
-					}
-				}
-			})
-			.then((children: TodoItemChildren<RenderMixin<any>>) => {
-				if (destroyed) {
-					return;
-				}
-
-				/* TODO: We are only using the label.widget but we are storing label: { id, widget }, is
-					* that necessary? */
-				childrenMap.set(instance, children);
-				instance.on('statechange', manageChildren);
-
-				/* We have missed the widgets initial state change because we created the widgets async
-					* so we should set state on the instance, so it will re-calculate its children */
-				instance.setState({});
-			})
-			.catch((err) => {
-				instance.emit({
-					type: 'error',
-					target: instance,
-					error: err
-				});
-			});
+const createLabel = createWidgetBase.extend({
+	tagName: 'label',
+	nodeAttributes: [
+		function (this: any): any {
+			return { innerHTML: this.state.label };
 		}
-	})
+	]
+});
+
+const createTodoItem = createWidgetBase
 	.extend({
-		get classes(this: TodoItem): string[] {
-			/* TODO: Deal with this in nodeAttributes when class classes are implementend */
-			const classes: string[] = [];
-			if (this.state.editing) {
-				classes.push('editing');
+		nodeAttributes: [
+			function(this: TodoItem): VNodeProperties {
+				const { completed, editing } = this.state;
+				return {
+					classes: { completed, editing }
+				};
 			}
-			return this.state.completed ? [ 'completed', ...classes ] : classes;
-		},
-
-		getChildrenNodes(this: TodoItem): VNode[] {
-			const { checkbox, label, button, editInput } = childrenMap.get(this);
-			return [
-				h('div.view', [
-					checkbox.widget.render(),
-					label.widget.render(),
-					button.widget.render()
-				]),
-				editInput.widget.render()
-			];
-		},
-
+		],
+		childNodeRenderers: [
+			function(this: TodoItem): DNode[] {
+				const state = this.state;
+				const checked = state.completed;
+				const label = state.label;
+				const focused = state.editing;
+				return [
+					d('div.view', {}, [
+						d(createCheckboxInput, {
+							listeners: { change: () => { todoToggleComplete.do(state); } },
+							state: { classes: [ 'toggle' ], checked }
+						}),
+						d(createLabel, {
+							listeners: { dblclick: () => { todoEdit.do(state); } },
+							state: { label }
+						}),
+						d(createButton, {
+							listeners: { click: () => { todoRemove.do(state); } },
+							state: { classes: [ 'destroy' ] }
+						})
+					]),
+					d(createFocusableTextInput, {
+						listeners: {
+							blur: (evt: Event) => { todoSave.do({ state, evt }); },
+							keyup: (evt: Event) => { todoEditInput.do({ state, evt }); }
+						},
+						state: { value: label, focused, classes: [ 'edit' ] }
+					})
+				];
+			}
+		],
 		tagName: 'li'
 	});
 

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -7,6 +7,7 @@ import createCheckboxInput from './createCheckboxInput';
 import createFocusableTextInput from './createFocusableTextInput';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
 import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
+import { TextInputOptions } from 'dojo-widgets/createTextInput';
 
 export type TodoItemState = WidgetState & {
 	label: string;
@@ -45,6 +46,14 @@ const createTodoItem = createWidgetBase
 				const checked = state.completed;
 				const label = state.label;
 				const focused = state.editing;
+				const inputOptions: TextInputOptions = {
+					value: label,
+					listeners: {
+						blur: (evt: Event) => { todoSave.do({ state, event }); },
+						keyup: (evt: Event) => { todoEditInput.do({ state, event }); }
+					},
+					state: { focused, classes: [ 'edit' ] }
+				};
 				return [
 					d('div.view', {}, [
 						d(createCheckboxInput, {
@@ -61,13 +70,7 @@ const createTodoItem = createWidgetBase
 						})
 					]),
 					state.editing ?
-					d(createFocusableTextInput, {
-						listeners: {
-							blur: (evt: Event) => { todoSave.do({ state, event }); },
-							keyup: (evt: Event) => { todoEditInput.do({ state, event }); }
-						},
-						state: { initialValue: label, focused, classes: [ 'edit' ] }
-					}) : null
+					d(createFocusableTextInput, inputOptions) : null
 				];
 			}
 		],

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -23,7 +23,7 @@ const createLabel = createWidgetBase
 	.extend({
 		tagName: 'label',
 		nodeAttributes: [
-			function (this: any): any {
+			function (this: Widget<WidgetState & { label: string }>): VNodeProperties {
 				return { innerHTML: this.state.label };
 			}
 		]

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -6,6 +6,7 @@ import createButton from 'dojo-widgets/createButton';
 import createCheckboxInput from './createCheckboxInput';
 import createFocusableTextInput from './createFocusableTextInput';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
+import createVNodeEvented from 'dojo-widgets/mixins/createVNodeEvented';
 
 export type TodoItemState = WidgetState & {
 	label: string;
@@ -17,14 +18,16 @@ export type TodoItemOptions = WidgetOptions<TodoItemState>;
 
 export type TodoItem = Widget<TodoItemState>;
 
-const createLabel = createWidgetBase.extend({
-	tagName: 'label',
-	nodeAttributes: [
-		function (this: any): any {
-			return { innerHTML: this.state.label };
-		}
-	]
-});
+const createLabel = createWidgetBase
+	.mixin(createVNodeEvented)
+	.extend({
+		tagName: 'label',
+		nodeAttributes: [
+			function (this: any): any {
+				return { innerHTML: this.state.label };
+			}
+		]
+	});
 
 const createTodoItem = createWidgetBase
 	.extend({
@@ -57,13 +60,14 @@ const createTodoItem = createWidgetBase
 							state: { classes: [ 'destroy' ] }
 						})
 					]),
+					state.editing ?
 					d(createFocusableTextInput, {
 						listeners: {
 							blur: (evt: Event) => { todoSave.do({ state, evt }); },
 							keyup: (evt: Event) => { todoEditInput.do({ state, evt }); }
 						},
 						state: { value: label, focused, classes: [ 'edit' ] }
-					})
+					}) : null
 				];
 			}
 		],

--- a/todo-mvc/src/widgets/createTodoItem.ts
+++ b/todo-mvc/src/widgets/createTodoItem.ts
@@ -63,10 +63,10 @@ const createTodoItem = createWidgetBase
 					state.editing ?
 					d(createFocusableTextInput, {
 						listeners: {
-							blur: (evt: Event) => { todoSave.do({ state, evt }); },
-							keyup: (evt: Event) => { todoEditInput.do({ state, evt }); }
+							blur: (evt: Event) => { todoSave.do({ state, event }); },
+							keyup: (evt: Event) => { todoEditInput.do({ state, event }); }
 						},
-						state: { value: label, focused, classes: [ 'edit' ] }
+						state: { initialValue: label, focused, classes: [ 'edit' ] }
 					}) : null
 				];
 			}

--- a/todo-mvc/src/widgets/createTodoList.ts
+++ b/todo-mvc/src/widgets/createTodoList.ts
@@ -1,53 +1,38 @@
-import createParentListMixin, { ParentList, ParentListMixinOptions } from 'dojo-widgets/mixins/createParentListMixin';
-import createRenderMixin, { RenderMixin, RenderMixinOptions, RenderMixinState } from 'dojo-widgets/mixins/createRenderMixin';
-import createStatefulChildrenMixin, { StatefulChildrenState, StatefulChildrenOptions } from 'dojo-widgets/mixins/createStatefulChildrenMixin';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
+import d from 'dojo-widgets/util/d';
+import createTodoItem, { TodoItem, TodoItemState } from './createTodoItem';
 
-import { VNode } from 'maquette';
-import { List } from 'immutable';
-
-import { TodoItem } from './createTodoItem';
-
-type TodoListState = RenderMixinState & StatefulChildrenState & {
+type TodoListState = WidgetState & {
 	activeFilter?: string;
+	todos: TodoItem[];
 };
 
-type TodoListOptions = RenderMixinOptions<TodoListState> & ParentListMixinOptions<TodoItem> & StatefulChildrenOptions<TodoItem, TodoListState>;
+type TodoListOptions = WidgetOptions<TodoListState>;
 
-export type TodoList = RenderMixin<TodoListState> & ParentList<TodoItem> & {
-	children: List<TodoItem>;
-};
+export type TodoList = Widget<TodoListState>;
 
-function filterCompleted(children: List<TodoItem>): List<TodoItem> {
-	return <List<TodoItem>> children.filter((child) => {
-		return child.state.completed;
-	});
+function filter(filterName: string, todo: TodoItemState): boolean {
+	switch (filterName) {
+		case 'completed':
+			return todo.completed;
+		case 'active':
+			return !todo.completed;
+		default:
+			return true;
+	}
 }
 
-function filterActive(children: List<TodoItem>): List<TodoItem> {
-	return <List<TodoItem>> children.filter((child) => {
-		return !child.state.completed;
-	});
-}
-
-const createTodoList = createRenderMixin
-	.mixin(createParentListMixin)
-	.mixin(createStatefulChildrenMixin)
+const createTodoList = createWidgetBase
 	.extend({
-		getChildrenNodes(this: TodoList): (VNode | string)[] {
-			const results: (VNode | string)[] = [];
-			const { children } = this;
-			let filteredChildren = children;
-
-			if (this.state.activeFilter === 'completed') {
-				filteredChildren = filterCompleted(children);
-			}
-			else if (this.state.activeFilter === 'active') {
-				filteredChildren = filterActive(children);
-			}
-			filteredChildren.forEach((child) => results.push(child.render()));
-			return results;
-		},
-
+		childNodeRenderers: [
+			function(this: TodoList): DNode[] {
+				const todos = this.state.todos || [];
+				return todos
+					.filter((todo: any) => filter(this.state.activeFilter, todo))
+					.map((todo: any) => d(createTodoItem, { id: todo.id, state: todo }));
+				}
+		],
 		tagName: 'ul'
 	});
 

--- a/todo-mvc/src/widgets/createTodoList.ts
+++ b/todo-mvc/src/widgets/createTodoList.ts
@@ -1,11 +1,11 @@
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import { Widget, WidgetOptions, WidgetState, DNode } from 'dojo-interfaces/widgetBases';
 import d from 'dojo-widgets/util/d';
-import createTodoItem, { TodoItem, TodoItemState } from './createTodoItem';
+import createTodoItem, { TodoItemState } from './createTodoItem';
 
 type TodoListState = WidgetState & {
 	activeFilter?: string;
-	todos: TodoItem[];
+	todos: TodoItemState[];
 };
 
 type TodoListOptions = WidgetOptions<TodoListState>;
@@ -29,8 +29,8 @@ const createTodoList = createWidgetBase
 			function(this: TodoList): DNode[] {
 				const todos = this.state.todos || [];
 				return todos
-					.filter((todo: any) => filter(this.state.activeFilter, todo))
-					.map((todo: any) => d(createTodoItem, { id: todo.id, state: todo }));
+					.filter((todo) => filter(this.state.activeFilter, todo))
+					.map((todo) => d(createTodoItem, { id: todo.id, state: todo }));
 				}
 		],
 		tagName: 'ul'


### PR DESCRIPTION
This is a fairly exhaustive refactor:

* Move all widgets over to the new WidgetBase
* Use `d` over `h`
* Use `d` for child widgets over `createChildren`
* Use `dojo-interfaces` where possible
* Change `createTodoList` to a Composite widget (may be switched later again when the final Container work is complete)
