### PR TITLE
Implement Todo without App

### DIFF
--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -26,17 +26,15 @@
     "dojo-interfaces": ">=2.0.0-alpha.4",
     "grunt": "^1.0.1",
     "grunt-dojo2": "^2.0.0-beta.16",
-    "intern": "~3.3.2",
+    "intern": "^3.3.2",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3"
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
     "dojo-actions": ">=2.0.0-alpha.9",
-    "dojo-app": ">=2.0.0-alpha.8",
     "dojo-compose": ">=2.0.0-beta.13",
     "dojo-core": ">=2.0.0-alpha.16",
-    "dojo-dom": ">=2.0.0-alpha.5",
     "dojo-has": ">=2.0.0-alpha.5",
     "dojo-loader": ">=2.0.0-beta.7",
     "dojo-routing": ">=2.0.0-alpha.5",

--- a/todo-mvc/src/app.ts
+++ b/todo-mvc/src/app.ts
@@ -17,10 +17,16 @@ const createApp = createWidgetBase.mixin({
 			function(this: Widget<WidgetState>): DNode[] {
 				const stateFrom = stateFromMap.get(this);
 
+				const inputOptions: WidgetOptions<WidgetState> = {
+					id: 'new-todo',
+					stateFrom,
+					listeners: { keypress: todoInput }
+				};
+
 				return [
 					d('header', {}, [
 						d(createTitle, <WidgetOptions<WidgetState>> { id: 'title', stateFrom }),
-						d(createFocusableTextInput, <WidgetOptions<WidgetState>> { id: 'new-todo', stateFrom, listeners: { keypress: todoInput } })
+						d(createFocusableTextInput, inputOptions)
 					]),
 					d(createMainSection, <WidgetOptions<WidgetState>>  { id: 'main-section', stateFrom }),
 					d(createTodoFooter, <WidgetOptions<WidgetState>> { id: 'todo-footer', stateFrom })

--- a/todo-mvc/src/app.ts
+++ b/todo-mvc/src/app.ts
@@ -1,0 +1,40 @@
+import { DNode, Widget, WidgetState, WidgetOptions } from 'dojo-interfaces/widgetBases';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { todoInput } from './actions/userActions';
+import d from 'dojo-widgets/util/d';
+
+import createTitle from './widgets/createTitle';
+import createMainSection from './widgets/createMainSection';
+import createFocusableTextInput from './widgets/createFocusableTextInput';
+import createTodoFooter from './widgets/createTodoFooter';
+
+const stateFromMap = new WeakMap<Widget<WidgetState>, any>();
+
+const createApp = createWidgetBase.mixin({
+	mixin: {
+		childNodeRenderers: [
+			function(this: Widget<WidgetState>): DNode[] {
+				const stateFrom = stateFromMap.get(this);
+
+				return [
+					d('header', {}, [
+						d(createTitle, <WidgetOptions<WidgetState>> { id: 'title', stateFrom }),
+						d(createFocusableTextInput, <WidgetOptions<WidgetState>> { id: 'new-todo', stateFrom, listeners: { keypress: todoInput } })
+					]),
+					d(createMainSection, <WidgetOptions<WidgetState>>  { id: 'main-section', stateFrom }),
+					d(createTodoFooter, <WidgetOptions<WidgetState>> { id: 'todo-footer', stateFrom })
+				];
+			}
+		],
+		classes: [ 'todoapp' ],
+		tagName: 'section'
+	},
+	initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState>) {
+		const { stateFrom } = options;
+		if (stateFrom) {
+			stateFromMap.set(instance, stateFrom);
+		}
+	}
+});
+
+export default createApp;

--- a/todo-mvc/src/app.ts
+++ b/todo-mvc/src/app.ts
@@ -1,5 +1,6 @@
 import { DNode, Widget, WidgetState, WidgetOptions } from 'dojo-interfaces/widgetBases';
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import WeakMap from 'dojo-shim/WeakMap';
 import { todoInput } from './actions/userActions';
 import d from 'dojo-widgets/util/d';
 

--- a/todo-mvc/src/app.ts
+++ b/todo-mvc/src/app.ts
@@ -3,13 +3,14 @@ import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import WeakMap from 'dojo-shim/WeakMap';
 import { todoInput } from './actions/userActions';
 import d from 'dojo-widgets/util/d';
+import { StoreObservablePatchable } from 'dojo-interfaces/abilities';
 
 import createTitle from './widgets/createTitle';
 import createMainSection from './widgets/createMainSection';
 import createFocusableTextInput from './widgets/createFocusableTextInput';
 import createTodoFooter from './widgets/createTodoFooter';
 
-const stateFromMap = new WeakMap<Widget<WidgetState>, any>();
+const stateFromMap = new WeakMap<Widget<WidgetState>, StoreObservablePatchable<WidgetState>>();
 
 const createApp = createWidgetBase.mixin({
 	mixin: {
@@ -25,11 +26,11 @@ const createApp = createWidgetBase.mixin({
 
 				return [
 					d('header', {}, [
-						d(createTitle, <WidgetOptions<WidgetState>> { id: 'title', stateFrom }),
+						d(createTitle, { id: 'title', stateFrom }),
 						d(createFocusableTextInput, inputOptions)
 					]),
-					d(createMainSection, <WidgetOptions<WidgetState>>  { id: 'main-section', stateFrom }),
-					d(createTodoFooter, <WidgetOptions<WidgetState>> { id: 'todo-footer', stateFrom })
+					d(createMainSection, { id: 'main-section', stateFrom }),
+					d(createTodoFooter, { id: 'todo-footer', stateFrom })
 				];
 			}
 		],

--- a/todo-mvc/src/index.html
+++ b/todo-mvc/src/index.html
@@ -5,21 +5,7 @@
 		<title>dojo2 todo mvc</title>
 	</head>
 	<body>
-		<section class="todoapp">
-			<header>
-				<app-projector>
-					<todo-title data-uid="title"></todo-title>
-					<div is="app-widget" id="new-todo"/>
-				</app-projector>
-			</header>
-			<app-projector>
-				<div is="app-widget" id="main-section">
-					<div is="app-widget" id="todo-list"></div>
-					<div is="app-widget" id="todo-toggle"></div>
-				</div>
-				<div is="app-widget" id="todo-footer"></div>
-			</app-projector>
-		</section>
+		<my-app></my-app>
 		<footer class="info">
 			<p>Double-click to edit a todo</p>
 			<p>Credits:

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,73 +1,19 @@
-import createApp from 'dojo-app/createApp';
-import createPanel from 'dojo-widgets/createPanel';
-import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
-import { todoToggleAll, todoInput } from './actions/userActions';
 import router from './routes';
-import todoStore, { bindActions as bindTodoStoreActions } from './stores/todoStore';
+import { bindActions as bindTodoStoreActions } from './stores/todoStore';
 import widgetStore from './stores/widgetStore';
-import createCheckboxInput from './widgets/createCheckboxInput';
-import createFocusableTextInput from './widgets/createFocusableTextInput';
-import createTodoFooter from './widgets/createTodoFooter';
-import createTodoItem from './widgets/createTodoItem';
-import createTodoList from './widgets/createTodoList';
-import { Widget, WidgetState } from 'dojo-interfaces/widgetBases';
-import { VNodeProperties } from 'dojo-interfaces/vdom';
+import { createProjector } from 'dojo-widgets/projector';
 
-const app = createApp({ defaultWidgetStore: widgetStore });
+import createApp from './app';
 
-const createTitle = createWidgetBase.extend({
-	tagName: 'h1',
-	nodeAttributes: [
-		function (this: Widget<WidgetState & { label: string }>): VNodeProperties {
-			return { innerHTML: this.state.label };
-		}
-	]
+const app = createApp({
+	id: 'app',
+	stateFrom: widgetStore
 });
 
-app.registerStore('todo-store', todoStore);
-app.loadDefinition({
-	widgets: [
-		{
-			id: 'new-todo',
-			factory: createFocusableTextInput,
-			listeners: {
-				keypress: todoInput
-			}
-		},
-		{
-			id: 'main-section',
-			factory: createPanel,
-			options: {
-				tagName: 'section'
-			}
-		},
-		{
-			id: 'todo-list',
-			factory: createTodoList
-		},
-		{
-			id: 'todo-toggle',
-			factory: createCheckboxInput,
-			listeners: {
-				change: todoToggleAll
-			}
-		},
-		{
-			id: 'todo-footer',
-			factory: createTodoFooter
-		}
-	],
-	customElements: [
-		{
-			name: 'todo-title',
-			factory: createTitle
-		},
-		{
-			name: 'todo-item',
-			factory: createTodoItem
-		}
-	]
-});
-Promise.resolve(app.realize(document.body))
+const root = document.getElementsByTagName('my-app')[0];
+const projector = createProjector({ root });
+
+projector.append(app);
+projector.attach()
 	.then(() => bindTodoStoreActions())
 	.then(() => router.start());

--- a/todo-mvc/src/widgets/createMainSection.ts
+++ b/todo-mvc/src/widgets/createMainSection.ts
@@ -2,12 +2,13 @@ import { DNode, Widget, WidgetState, WidgetOptions } from 'dojo-interfaces/widge
 import WeakMap from 'dojo-shim/WeakMap';
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import d from 'dojo-widgets/util/d';
+import { StoreObservablePatchable } from 'dojo-interfaces/abilities';
 
 import { todoToggleAll } from '../actions/userActions';
 import createCheckboxInput from './createCheckboxInput';
 import createTodoList from './createTodoList';
 
-const stateFromMap = new WeakMap<Widget<WidgetState>, any>();
+const stateFromMap = new WeakMap<Widget<WidgetState>, StoreObservablePatchable<WidgetState>>();
 
 const createMainSection = createWidgetBase.mixin({
 	mixin: {
@@ -15,12 +16,6 @@ const createMainSection = createWidgetBase.mixin({
 		childNodeRenderers: [
 			function (this: Widget<WidgetState>): DNode[] {
 				const stateFrom = stateFromMap.get(this);
-
-				const todoListOptions = {
-					id: 'todo-list',
-					stateFrom
-				};
-
 				const checkBoxOptions = {
 					id: 'todo-toggle',
 					stateFrom,
@@ -30,7 +25,7 @@ const createMainSection = createWidgetBase.mixin({
 				};
 
 				return [
-					d(createTodoList, <WidgetOptions<WidgetState>> todoListOptions),
+					d(createTodoList, { id: 'todo-list', stateFrom }),
 					d(createCheckboxInput, <WidgetOptions<WidgetState> > checkBoxOptions)
 				];
 			}

--- a/todo-mvc/src/widgets/createMainSection.ts
+++ b/todo-mvc/src/widgets/createMainSection.ts
@@ -1,0 +1,46 @@
+import { DNode, Widget, WidgetState, WidgetOptions } from 'dojo-interfaces/widgetBases';
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import d from 'dojo-widgets/util/d';
+
+import { todoToggleAll } from '../actions/userActions';
+import createCheckboxInput from './createCheckboxInput';
+import createTodoList from './createTodoList';
+
+const stateFromMap = new WeakMap<Widget<WidgetState>, any>();
+
+const createMainSection = createWidgetBase.mixin({
+	mixin: {
+		tagName: 'section',
+		childNodeRenderers: [
+			function (this: Widget<WidgetState>): DNode[] {
+				const stateFrom = stateFromMap.get(this);
+
+				const todoListOptions = {
+					id: 'todo-list',
+					stateFrom
+				};
+
+				const checkBoxOptions = {
+					id: 'todo-toggle',
+					stateFrom,
+					listeners: {
+						change: todoToggleAll
+					}
+				};
+
+				return [
+					d(createTodoList, <any> todoListOptions),
+					d(createCheckboxInput, <any> checkBoxOptions)
+				];
+			}
+		]
+	},
+	initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState>) {
+		const { stateFrom } = options;
+		if (stateFrom) {
+			stateFromMap.set(instance, stateFrom);
+		}
+	}
+});
+
+export default createMainSection;

--- a/todo-mvc/src/widgets/createMainSection.ts
+++ b/todo-mvc/src/widgets/createMainSection.ts
@@ -1,4 +1,5 @@
 import { DNode, Widget, WidgetState, WidgetOptions } from 'dojo-interfaces/widgetBases';
+import WeakMap from 'dojo-shim/WeakMap';
 import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
 import d from 'dojo-widgets/util/d';
 
@@ -29,8 +30,8 @@ const createMainSection = createWidgetBase.mixin({
 				};
 
 				return [
-					d(createTodoList, <any> todoListOptions),
-					d(createCheckboxInput, <any> checkBoxOptions)
+					d(createTodoList, <WidgetOptions<WidgetState>> todoListOptions),
+					d(createCheckboxInput, <WidgetOptions<WidgetState> > checkBoxOptions)
 				];
 			}
 		]

--- a/todo-mvc/src/widgets/createTitle.ts
+++ b/todo-mvc/src/widgets/createTitle.ts
@@ -1,0 +1,14 @@
+import createWidgetBase from 'dojo-widgets/bases/createWidgetBase';
+import { Widget, WidgetState } from 'dojo-interfaces/widgetBases';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
+
+const createTitle = createWidgetBase.extend({
+	tagName: 'h1',
+	nodeAttributes: [
+		function (this: Widget<WidgetState & { label: string }>): VNodeProperties {
+			return { innerHTML: this.state.label };
+		}
+	]
+});
+
+export default createTitle;

--- a/todo-mvc/typings.json
+++ b/todo-mvc/typings.json
@@ -10,12 +10,6 @@
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
 	},
 	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
-		"jquery": "registry:dt/jquery#1.10.0+20160417213236",
-		"jsdom": "registry:dt/jsdom#2.0.0+20160316155526",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b"
+		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
 	}
 }


### PR DESCRIPTION
There is no real need for todoMVC to use `app`, refactored the application to use widgets and `d` only once PR landed that passes `stateFrom` there are few `WeakMap`s that can be removed also.