### PR TITLE
pin stores version in preperation for the next major release pre beta

### DIFF
--- a/monster-cards/package.json
+++ b/monster-cards/package.json
@@ -26,7 +26,7 @@
     "dojo-loader": ">=2.0.0-beta.7",
     "dojo-routing": ">=2.0.0-alpha.5",
     "dojo-shim": ">=2.0.0-beta.3",
-    "dojo-stores": ">=2.0.0-alpha.4",
+    "dojo-stores": "2.0.0-alpha.4",
     "dojo-widgets": "2.0.0-alpha.12",
     "font-awesome": "~4.6.3",
     "immutable": "~3.8.1",

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -41,7 +41,7 @@
     "dojo-loader": ">=2.0.0-beta.7",
     "dojo-routing": ">=2.0.0-alpha.5",
     "dojo-shim": ">=2.0.0-beta.3",
-    "dojo-stores": ">=2.0.0-alpha.4",
+    "dojo-stores": "2.0.0-alpha.4",
     "dojo-widgets": ">=2.0.0-alpha.13",
     "immutable": "^3.8.1",
     "maquette": ">=2.3.7 <=2.4.1",


### PR DESCRIPTION
This is so that once the new stores package is published examples don't start breaking :)