### PR TITLE
Remove node_modules cache from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: PROJECT_DIR=auto-deploy
-cache:
-  directories:
-  - $PROJECT_DIR/node_modules
 install:
 - ./scripts/install.sh
 script:


### PR DESCRIPTION
<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Remove node_modules cache from .travis.yml

**Related Issue:** #75

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged