### PR TITLE
Update URL for dojo test config

### DIFF
--- a/todo-mvc/tests/functional/Page.ts
+++ b/todo-mvc/tests/functional/Page.ts
@@ -76,7 +76,7 @@ export default class Page {
 
 	init(): Promise<any> {
 		return this.remote
-			.get(require.toUrl('../../src/index.html'))
+			.get(require.toUrl('src/index.html'))
 			.setFindTimeout(5000)
 			.findByCssSelector(this.selectors.newInput)
 			.setFindTimeout(100);


### PR DESCRIPTION
When running `dojo test`, the URL currently being used in this test doesn't work, as it's resolved relative to the project directory.  The intern config maps `tests` and `src` to `_build/tests` and `_build/src` respectively so the actual path from the project root can be used instead.