### PR TITLE
Add ClientErrorCollector Helper

### DIFF
--- a/todo-mvc-kitchensink/tests/functional/Page.ts
+++ b/todo-mvc-kitchensink/tests/functional/Page.ts
@@ -10,6 +10,8 @@ import * as todoListItem from './../../src/widgets/styles/TodoItem.css';
 import * as todoListCss from './../../src/widgets/styles/TodoItemList.css';
 import * as toggler from './../../src/widgets/styles/Toggler.css';
 
+import ClientErrorCollector from '../support/ClientErrorCollector';
+
 class Selectors {
 	public main = `.${appCss.todoapp}`;
 	public footer = `.${todoFooterCss.footer}`;
@@ -64,10 +66,12 @@ class Selectors {
 export default class Page {
 	private remote: any;
 	private selectors: Selectors;
+	private errorCollector: ClientErrorCollector;
 
 	constructor(remote: any) {
 		this.remote = remote;
 		this.selectors = new Selectors();
+		this.errorCollector = new ClientErrorCollector(remote);
 	}
 
 	delay(): Promise<any> {
@@ -79,7 +83,10 @@ export default class Page {
 			.get('http://localhost:9000/_build/src/index.html')
 			.setFindTimeout(5000)
 			.findByCssSelector(this.selectors.newInput)
-			.setFindTimeout(100);
+			.setFindTimeout(100)
+			.then(() => {
+				return this.errorCollector.init()
+			});
 	}
 
 	isMainVisible(): Promise<boolean> {
@@ -143,6 +150,10 @@ export default class Page {
 		return texts.reduce((promise, text) => {
 			return promise.then(() => this.enterItem(text));
 		}, Promise.resolve());
+	}
+
+	finish(): Promise<undefined> {
+		return this.errorCollector.assertNoErrors();
 	}
 
 	getCompletedCount(): Promise<number> {

--- a/todo-mvc-kitchensink/tests/functional/Page.ts
+++ b/todo-mvc-kitchensink/tests/functional/Page.ts
@@ -85,7 +85,7 @@ export default class Page {
 			.findByCssSelector(this.selectors.newInput)
 			.setFindTimeout(100)
 			.then(() => {
-				return this.errorCollector.init()
+				return this.errorCollector.init();
 			});
 	}
 

--- a/todo-mvc-kitchensink/tests/functional/main.ts
+++ b/todo-mvc-kitchensink/tests/functional/main.ts
@@ -5,7 +5,7 @@ import '@dojo/shim/Promise';
 
 test.describe('TodoMVC - Dojo 2', function (this: any) {
 
-	let page: any;
+	let page: Page;
 
 	const TODO_ITEM_ONE = 'buy some cheese';
 	const TODO_ITEM_TWO = 'feed the cat';
@@ -14,6 +14,10 @@ test.describe('TodoMVC - Dojo 2', function (this: any) {
 	test.beforeEach(() => {
 		page = new Page(this.remote);
 		return page.init();
+	});
+
+	test.afterEach(() => {
+		return page.finish();
 	});
 
 	test.describe('When page is initially opened', function () {

--- a/todo-mvc-kitchensink/tests/support/ClientErrorCollector.ts
+++ b/todo-mvc-kitchensink/tests/support/ClientErrorCollector.ts
@@ -50,7 +50,7 @@ export default class ClientErrorCollector {
 
 	finish(): Promise<ClientError[] | undefined> {
 		if (!this._inited) {
-			throw new Error('ErrorHelper not initialised.');
+			throw new Error('ClientErrorCollector not initialised.');
 		}
 
 		return this._remote
@@ -64,7 +64,7 @@ export default class ClientErrorCollector {
 
 		init(): Promise<void> {
 		if (this._inited) {
-			throw new Error('ErrorHelper already initialised.');
+			throw new Error('ClientErrorCollector already initialised.');
 		}
 
 		return this._remote

--- a/todo-mvc-kitchensink/tests/support/ClientErrorCollector.ts
+++ b/todo-mvc-kitchensink/tests/support/ClientErrorCollector.ts
@@ -1,0 +1,111 @@
+export interface ClientError {
+	message: string;
+	type: string;
+	source: string;
+	lineno: number;
+	colno: number;
+	error: {
+		message: string;
+		name: string;
+		stack?: string;
+	};
+}
+
+export default class ClientErrorCollector {
+	private _remote: any;
+	private _inited: boolean = false;
+
+	constructor (remote: any) {
+		this._remote = remote;
+	}
+
+	assertNoErrors(message?: string): Promise<undefined> {
+		return this.finish()
+			.then((results) => {
+				if (results && results.length) {
+					const result = results[0];
+					let e: Error;
+					switch (result.type) {
+					case 'TypeError':
+						e = new TypeError(result.message);
+						break;
+					case 'SyntaxError':
+						e = new SyntaxError(result.message);
+						break;
+					default:
+						e = new Error(result.message);
+					}
+					e.stack = result.error.stack;
+					(<any> e).fileName = result.source;
+					(<any> e).lineNumber = result.lineno;
+					(<any> e).columnNumber = result.colno;
+					throw e;
+				}
+			});
+	}
+
+	finish(): Promise<ClientError[] | undefined> {
+		if (!this._inited) {
+			throw new Error('ErrorHelper not initialised.');
+		}
+
+		return this._remote
+			.execute(`return window.__intern_error_helper_finish();`)
+			.then((results: string | undefined) => {
+				if (results) {
+					return JSON.parse(results);
+				}
+			});
+	}
+
+		init(): Promise<void> {
+		if (this._inited) {
+			throw new Error('ErrorHelper already initialised.');
+		}
+
+		return this._remote
+			.execute(`
+				var errorStack = window.__intern_error_stack = [];
+				var oldonerror;
+				if (window.onerror) {
+					oldonerror = window.__intern_old_onerror = window.onerror;
+				}
+				window.onerror = function (message, source, lineno, colno, error) {
+					var errorObj = {
+						message: message,
+						source: source,
+						lineno: lineno,
+						colno: colno
+					};
+
+					if (error) {
+						errorObj.error = {
+							message: error.message,
+							name: error.name,
+							stack: error.stack
+						}
+					}
+
+					errorStack.push(errorObj);
+
+					if (oldonerror) {
+						oldonerror.call(this, messageOrEvent, source, lineno, colno, error);
+					}
+				}
+				window.__intern_error_helper_finish = function () {
+					if (typeof window.__intern_old_onerror !== 'undefined') {
+						window.onerror = window.__intern_old_onerror;
+					}
+					else {
+						delete window.onerror;
+					}
+					var errorStack = window.__intern_error_stack;
+					delete window.__intern_error_stack;
+					return JSON.stringify(errorStack);
+				};
+			`)
+			.then(() => {
+				this._inited = true;
+			});
+	}
+}


### PR DESCRIPTION
This PR adds `ClientErrorCollector` to the kitchen sink repo.

`ClientErrorCollector` is a LeadFoot helper that is designed to capture client error in functional tests that might occur, and are not desired, but do not cause the functional test to fail.  It is a class that provides three methods:

- `init()` - Initialises the collector, installing a global `onerror` handler which will collect any errors
- `finish()` - Uninstall the collector and return a Promise that resolves to an array of any errors
- `assertNoErrors()` - Implicitly calls `finish()` and will reject if there are any errors, rejecting on the first error in the stack

This then is integrated into the functional tests for kitchen sink.

Refs #196