### PR TITLE
Updated dojo-cli-example to have npm dep of 3+

### DIFF
--- a/dojo-cli-example/package.json
+++ b/dojo-cli-example/package.json
@@ -15,6 +15,7 @@
     "typings.json"
   ],
   "engines": {
+    "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
   "repository": {

--- a/dojo-cli-example/package.json
+++ b/dojo-cli-example/package.json
@@ -14,6 +14,9 @@
     "src",
     "typings.json"
   ],
+  "engines": {
+    "npm": ">=3.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/dojo/examples.git"


### PR DESCRIPTION
All other example apps are unchanged as they already specified `npm` 3+ and `node` 6+.

[ci skip]

Refs dojo/meta#156