### PR TITLE
Use a unique package name with todo-mvc-kitchensink

### DIFF
--- a/todo-mvc-kitchensink/package.json
+++ b/todo-mvc-kitchensink/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo2-todo-mvc",
+  "name": "dojo2-todo-mvc-kitchensink",
   "version": "0.0.1",
   "description": "TodoMVC using Dojo 2",
   "main": "index.js",


### PR DESCRIPTION
This PR simply changes the package name of `todo-mvc-kitchensink` so that if someone is depending on the name of `package.json` (like exporting to the web-editor) its name does not conflict.