### PR TITLE
Upgrade examples to use Beta2

### DIFF
--- a/todo-mvc-kitchensink/package.json
+++ b/todo-mvc-kitchensink/package.json
@@ -16,10 +16,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "next",
-    "@dojo/cli-test-intern": "next",
-    "@dojo/interfaces": "next",
-    "@dojo/loader": "next",
+    "@dojo/cli-build-webpack": "beta2",
+    "@dojo/cli-test-intern": "beta2",
+    "@dojo/interfaces": "beta2",
+    "@dojo/loader": "beta2",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -29,12 +29,12 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "next",
-    "@dojo/has": "next",
-    "@dojo/routing": "next",
-    "@dojo/shim": "next",
-    "@dojo/widget-core": "next",
-    "@dojo/i18n": "next",
+    "@dojo/core": "beta2",
+    "@dojo/has": "beta2",
+    "@dojo/routing": "beta2",
+    "@dojo/shim": "beta2",
+    "@dojo/widget-core": "beta2",
+    "@dojo/i18n": "beta2",
     "cldr-data": "~30.0.2",
     "@webcomponents/custom-elements": "^1.0.0-alpha.3"
   }

--- a/todo-mvc-kitchensink/src/TodoAppContext.ts
+++ b/todo-mvc-kitchensink/src/TodoAppContext.ts
@@ -1,6 +1,8 @@
 import { Evented } from '@dojo/core/Evented';
 import uuid from '@dojo/core/uuid';
+import { switchLocale } from '@dojo/i18n/i18n';
 
+import pirateThemeStyles from './themes/pirate';
 export interface Todo {
 	id: string;
 	label: string;
@@ -27,6 +29,13 @@ export class TodoAppContext extends Evented {
 	private _currentSearch = '';
 
 	private _editedTodo: Todo | undefined;
+
+	private _themeContext: any;
+
+	public constructor(themeContext: any) {
+		super();
+		this._themeContext = themeContext;
+	}
 
 	public get todos(): Todo[] {
 		return Object.keys(this._todos).map((key) => {
@@ -154,6 +163,17 @@ export class TodoAppContext extends Evented {
 		this._todoCount = Object.keys(this._todos).length;
 		this._completed = false;
 		this._invalidate();
+	}
+
+	public changeTheme(wantsPirate: boolean) {
+		if (wantsPirate) {
+			switchLocale('en-PR');
+			this._themeContext.set(pirateThemeStyles);
+		}
+		else {
+			switchLocale('en');
+			this._themeContext.set(undefined);
+		}
 	}
 
 	private _toggleAllTodos() {

--- a/todo-mvc-kitchensink/src/containers/ThemeSwitcherContainer.ts
+++ b/todo-mvc-kitchensink/src/containers/ThemeSwitcherContainer.ts
@@ -1,27 +1,11 @@
 import { Container } from '@dojo/widget-core/Container';
-import { switchLocale } from '@dojo/i18n/i18n';
-import { registerThemeInjector } from '@dojo/widget-core/mixins/Themeable';
 
 import { TodoAppContext } from './../TodoAppContext';
 import { ThemeSwitcher } from './../widgets/ThemeSwitcher';
-import pirateThemeStyles from './../themes/pirate';
-
-const themeContext = registerThemeInjector(undefined);
-
-function changeTheme(wantsPirate: boolean) {
-	if (wantsPirate) {
-		switchLocale('en-PR');
-		themeContext.set(pirateThemeStyles);
-	}
-	else {
-		switchLocale('en');
-		themeContext.set(undefined);
-	}
-}
 
 function getProperties(todoAppContext: TodoAppContext, properties: any) {
 	return {
-		changeTheme
+		changeTheme: todoAppContext.changeTheme.bind(todoAppContext)
 	};
 }
 

--- a/todo-mvc-kitchensink/src/main.ts
+++ b/todo-mvc-kitchensink/src/main.ts
@@ -1,13 +1,16 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
 import { BaseInjector, Injector } from '@dojo/widget-core/Injector';
-import { registry } from '@dojo/widget-core/d';
+import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
 
 import setLocaleData from './setLocaleData';
 import { TodoAppContext } from './TodoAppContext';
 import { TodoAppContainer } from './containers/TodoAppContainer';
+import { registerThemeInjector } from '@dojo/widget-core/mixins/Themeable';
 
-registry.define('state', Injector(BaseInjector, new TodoAppContext()));
+const registry = new WidgetRegistry();
+const themeContext = registerThemeInjector(undefined, registry);
+registry.define('state', Injector(BaseInjector, new TodoAppContext(themeContext)));
 
 const Projector = ProjectorMixin(TodoAppContainer);
 const projector = new Projector();
@@ -30,7 +33,11 @@ const config = [
 	}
 ];
 
-const router = registerRouterInjector(config);
+const router = registerRouterInjector(config, registry);
+
+// setting the registry should be promoted to defaultRegistry, however seems
+// there is an issue used with Containers/Injectors
+projector.setProperties({ defaultRegistry: registry } as any);
 
 setLocaleData().then(() => {
 	if (projector.root) {

--- a/todo-mvc-tsx/package.json
+++ b/todo-mvc-tsx/package.json
@@ -13,10 +13,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "next",
-    "@dojo/cli-test-intern": "next",
-    "@dojo/interfaces": "next",
-    "@dojo/loader": "next",
+    "@dojo/cli-build-webpack": "beta2",
+    "@dojo/cli-test-intern": "beta2",
+    "@dojo/interfaces": "beta2",
+    "@dojo/loader": "beta2",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -25,12 +25,12 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "next",
-    "@dojo/has": "next",
-    "@dojo/i18n": "next",
-    "@dojo/routing": "next",
-    "@dojo/shim": "next",
-    "@dojo/widget-core": "next",
+    "@dojo/core": "beta2",
+    "@dojo/has": "beta2",
+    "@dojo/i18n": "beta2",
+    "@dojo/routing": "beta2",
+    "@dojo/shim": "beta2",
+    "@dojo/widget-core": "beta2",
     "redux": "^3.7.2"
   }
 }

--- a/todo-mvc-tsx/src/main.ts
+++ b/todo-mvc-tsx/src/main.ts
@@ -1,8 +1,8 @@
 import global from '@dojo/shim/global';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
-import { registry } from '@dojo/widget-core/d';
 import { Injector, Base as BaseInjector } from '@dojo/widget-core/Injector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
+import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
 
 import { TodoAppContainer } from './containers/TodoAppContainer';
 import { createStore, Store } from 'redux';
@@ -14,6 +14,8 @@ const defaultState = {
 	activeCount: 0,
 	completedCount: 0
 };
+
+const registry = new WidgetRegistry();
 
 const store = createStore(todoReducer, defaultState, global.__REDUX_DEVTOOLS_EXTENSION__ && global.__REDUX_DEVTOOLS_EXTENSION__());
 
@@ -45,8 +47,11 @@ const config = [
 	}
 ];
 
-const router = registerRouterInjector(config);
+const router = registerRouterInjector(config, registry);
 const Projector = ProjectorMixin(TodoAppContainer);
 const projector = new Projector();
+// bug in widget-core that doesn't correctly promote registry
+// when using container with projector
+projector.setProperties({ defaultRegistry: registry } as any);
 projector.append();
 router.start();

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -16,10 +16,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "next",
-    "@dojo/cli-test-intern": "next",
-    "@dojo/interfaces": "next",
-    "@dojo/loader": "next",
+    "@dojo/cli-build-webpack": "beta2",
+    "@dojo/cli-test-intern": "beta2",
+    "@dojo/interfaces": "beta2",
+    "@dojo/loader": "beta2",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -28,11 +28,11 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "next",
-    "@dojo/has": "next",
-    "@dojo/i18n": "next",
-    "@dojo/routing": "next",
-    "@dojo/shim": "next",
-    "@dojo/widget-core": "next"
+    "@dojo/core": "beta2",
+    "@dojo/has": "beta2",
+    "@dojo/i18n": "beta2",
+    "@dojo/routing": "beta2",
+    "@dojo/shim": "beta2",
+    "@dojo/widget-core": "beta2"
   }
 }

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -28,7 +28,7 @@ const Projector = ProjectorMixin(TodoApp);
 const projector = new Projector();
 
 const router = registerRouterInjector([{ path: '{filter}', outlet: 'filter', defaultParams: { filter: 'all' }, defaultRoute: true }], registry);
-projector.__setProperties__({ registry });
+projector.setProperties({ registry });
 
 projector.append(root);
 router.start();

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,13 +1,34 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
 import TodoApp from './widgets/TodoApp';
+import { Outlet } from '@dojo/routing/Outlet';
+import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
+
+import TodoHeader from './widgets/TodoHeader';
+import TodoList from './widgets/TodoList';
+import TodoItem from './widgets/TodoItem';
+import TodoFooter from './widgets/TodoFooter';
+import TodoFilter from './widgets/TodoFilter';
+
+const registry = new WidgetRegistry();
+
+function mapFilterRouteParam({ params }: any) {
+	return { activeFilter: params.filter };
+}
+
+registry.define('todo-header', TodoHeader);
+registry.define('todo-list', Outlet(TodoList, 'filter', mapFilterRouteParam));
+registry.define('todo-item', TodoItem);
+registry.define('todo-footer', TodoFooter);
+registry.define('todo-filter', Outlet(TodoFilter, 'filter', mapFilterRouteParam));
 
 const root = document.querySelector('my-app') || undefined;
 
 const Projector = ProjectorMixin(TodoApp);
 const projector = new Projector();
 
-const router = registerRouterInjector([{ path: '{filter}', outlet: 'filter', defaultParams: { filter: 'all' }, defaultRoute: true }]);
+const router = registerRouterInjector([{ path: '{filter}', outlet: 'filter', defaultParams: { filter: 'all' }, defaultRoute: true }], registry);
+projector.__setProperties__({ registry });
 
 projector.append(root);
 router.start();

--- a/todo-mvc/src/widgets/TodoApp.ts
+++ b/todo-mvc/src/widgets/TodoApp.ts
@@ -4,26 +4,12 @@ import { assign } from '@dojo/core/lang';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { ThemeableMixin, theme } from '@dojo/widget-core/mixins/Themeable';
 import { w, v } from '@dojo/widget-core/d';
-import { registry } from '@dojo/widget-core/d';
-import { Outlet } from '@dojo/routing/Outlet';
 
 import TodoHeader from './TodoHeader';
 import TodoList from './TodoList';
-import TodoItem from './TodoItem';
 import TodoFooter from './TodoFooter';
-import TodoFilter from './TodoFilter';
 
 import * as css from './styles/todoApp.css';
-
-function mapFilterRouteParam({ params }: any) {
-	return { activeFilter: params.filter };
-}
-
-registry.define('todo-header', TodoHeader);
-registry.define('todo-list', Outlet(TodoList, 'filter', mapFilterRouteParam));
-registry.define('todo-item', TodoItem);
-registry.define('todo-footer', TodoFooter);
-registry.define('todo-filter', Outlet(TodoFilter, 'filter', mapFilterRouteParam));
 
 export interface Todo {
 	id: string;


### PR DESCRIPTION
Updates the todo-mvc examples to use the beta2 releases.

highlighted an area of improvement around registries (added comment, issue to follow)