### PR TITLE
Updates for latest widget-core

### DIFF
--- a/todo-mvc-kitchensink/package.json
+++ b/todo-mvc-kitchensink/package.json
@@ -16,10 +16,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "beta2",
-    "@dojo/cli-test-intern": "beta2",
-    "@dojo/interfaces": "beta2",
-    "@dojo/loader": "beta2",
+    "@dojo/cli-build-webpack": "next",
+    "@dojo/cli-test-intern": "next",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -29,12 +29,12 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "beta2",
-    "@dojo/has": "beta2",
-    "@dojo/routing": "beta2",
-    "@dojo/shim": "beta2",
-    "@dojo/widget-core": "beta2",
-    "@dojo/i18n": "beta2",
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/routing": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next",
+    "@dojo/i18n": "next",
     "cldr-data": "~30.0.2",
     "@webcomponents/custom-elements": "^1.0.0-alpha.3"
   }

--- a/todo-mvc-kitchensink/src/TodoAppContext.ts
+++ b/todo-mvc-kitchensink/src/TodoAppContext.ts
@@ -1,6 +1,6 @@
-import { Evented } from '@dojo/core/Evented';
 import uuid from '@dojo/core/uuid';
 import { switchLocale } from '@dojo/i18n/i18n';
+import { Injector } from '@dojo/widget-core/Injector';
 
 import pirateThemeStyles from './themes/pirate';
 export interface Todo {
@@ -14,7 +14,7 @@ export interface Todos {
 	[key: string]: Todo;
 }
 
-export class TodoAppContext extends Evented {
+export class TodoAppContext extends Injector {
 
 	private _todos: Todos = Object.create(null);
 
@@ -33,7 +33,7 @@ export class TodoAppContext extends Evented {
 	private _themeContext: any;
 
 	public constructor(themeContext: any) {
-		super();
+		super({});
 		this._themeContext = themeContext;
 	}
 
@@ -184,5 +184,9 @@ export class TodoAppContext extends Evented {
 
 	private _invalidate() {
 		this.emit({ type: 'invalidate' });
+	}
+
+	get() {
+		return this;
 	}
 }

--- a/todo-mvc-kitchensink/src/main.ts
+++ b/todo-mvc-kitchensink/src/main.ts
@@ -1,16 +1,15 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
-import { BaseInjector, Injector } from '@dojo/widget-core/Injector';
-import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
+import { Registry } from '@dojo/widget-core/Registry';
 
 import setLocaleData from './setLocaleData';
 import { TodoAppContext } from './TodoAppContext';
 import { TodoAppContainer } from './containers/TodoAppContainer';
 import { registerThemeInjector } from '@dojo/widget-core/mixins/Themeable';
 
-const registry = new WidgetRegistry();
+const registry = new Registry();
 const themeContext = registerThemeInjector(undefined, registry);
-registry.define('state', Injector(BaseInjector, new TodoAppContext(themeContext)));
+registry.defineInjector('state', new TodoAppContext(themeContext));
 
 const Projector = ProjectorMixin(TodoAppContainer);
 const projector = new Projector();
@@ -34,10 +33,7 @@ const config = [
 ];
 
 const router = registerRouterInjector(config, registry);
-
-// setting the registry should be promoted to defaultRegistry, however seems
-// there is an issue used with Containers/Injectors
-projector.setProperties({ defaultRegistry: registry } as any);
+projector.setProperties({ registry });
 
 setLocaleData().then(() => {
 	if (projector.root) {

--- a/todo-mvc-kitchensink/src/widgets/TodoApp.ts
+++ b/todo-mvc-kitchensink/src/widgets/TodoApp.ts
@@ -1,6 +1,5 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import  { v, w } from '@dojo/widget-core/d';
-import { DNode } from '@dojo/widget-core/interfaces';
 import { theme, ThemeableMixin } from '@dojo/widget-core/mixins/Themeable';
 
 import { ThemeSwitcherContainer } from './../containers/ThemeSwitcherContainer';
@@ -68,6 +67,6 @@ export class TodoApp extends TodoAppBase<TodoAppProperties> {
 				todoCount > 0 ? w(TodoFooterOutlet, { activeCount, todoCount, clearCompleted }) : null
 			]),
 			w(Credits, {})
-		];
+		]);
 	}
 }

--- a/todo-mvc-kitchensink/src/widgets/TodoApp.ts
+++ b/todo-mvc-kitchensink/src/widgets/TodoApp.ts
@@ -34,7 +34,7 @@ export const TodoAppBase = ThemeableMixin(WidgetBase);
 
 @theme(css)
 export class TodoApp extends TodoAppBase<TodoAppProperties> {
-	protected render(): DNode[] {
+	protected render() {
 		const {
 			todos,
 			addTodo,
@@ -52,7 +52,7 @@ export class TodoApp extends TodoAppBase<TodoAppProperties> {
 			clearCompleted
 		} = this.properties;
 
-		return [
+		return v('div', {}, [
 				v('section', { classes: this.classes(css.todoapp) }, [
 				w(ThemeSwitcherContainer, {}),
 				w(TodoHeader, {

--- a/todo-mvc-tsx/package.json
+++ b/todo-mvc-tsx/package.json
@@ -13,10 +13,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "beta2",
-    "@dojo/cli-test-intern": "beta2",
-    "@dojo/interfaces": "beta2",
-    "@dojo/loader": "beta2",
+    "@dojo/cli-build-webpack": "next",
+    "@dojo/cli-test-intern": "next",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -25,12 +25,13 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "beta2",
-    "@dojo/has": "beta2",
-    "@dojo/i18n": "beta2",
-    "@dojo/routing": "beta2",
-    "@dojo/shim": "beta2",
-    "@dojo/widget-core": "beta2",
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/i18n": "next",
+    "@dojo/interop": "^2.0.0-alpha.3",
+    "@dojo/routing": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next",
     "redux": "^3.7.2"
   }
 }

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -16,10 +16,10 @@
     "npm": ">=3"
   },
   "devDependencies": {
-    "@dojo/cli-build-webpack": "beta2",
-    "@dojo/cli-test-intern": "beta2",
-    "@dojo/interfaces": "beta2",
-    "@dojo/loader": "beta2",
+    "@dojo/cli-build-webpack": "next",
+    "@dojo/cli-test-intern": "next",
+    "@dojo/interfaces": "next",
+    "@dojo/loader": "next",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",
     "@types/node": "^6.0.46",
@@ -28,11 +28,11 @@
     "typescript": "~2.4.1"
   },
   "dependencies": {
-    "@dojo/core": "beta2",
-    "@dojo/has": "beta2",
-    "@dojo/i18n": "beta2",
-    "@dojo/routing": "beta2",
-    "@dojo/shim": "beta2",
-    "@dojo/widget-core": "beta2"
+    "@dojo/core": "next",
+    "@dojo/has": "next",
+    "@dojo/i18n": "next",
+    "@dojo/routing": "next",
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next"
   }
 }

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -2,7 +2,7 @@ import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
 import TodoApp from './widgets/TodoApp';
 import { Outlet } from '@dojo/routing/Outlet';
-import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
+import { Registry } from '@dojo/widget-core/Registry';
 
 import TodoHeader from './widgets/TodoHeader';
 import TodoList from './widgets/TodoList';
@@ -10,7 +10,7 @@ import TodoItem from './widgets/TodoItem';
 import TodoFooter from './widgets/TodoFooter';
 import TodoFilter from './widgets/TodoFilter';
 
-const registry = new WidgetRegistry();
+const registry = new Registry();
 
 function mapFilterRouteParam({ params }: any) {
 	return { activeFilter: params.filter };


### PR DESCRIPTION
Brings the examples inline with the latest dojo packages (released under `next`)