### PR TITLE
Add polyfills and tweak required to get todo-mvc running in IE9

### DIFF
--- a/todo-mvc/src/App.ts
+++ b/todo-mvc/src/App.ts
@@ -1,0 +1,10 @@
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import TodoApp from './widgets/TodoApp';
+import { w } from '@dojo/widget-core/d';
+
+export default class App extends WidgetBase {
+
+	render() {
+		return w(TodoApp, {});
+	}
+}

--- a/todo-mvc/src/main.ts
+++ b/todo-mvc/src/main.ts
@@ -1,6 +1,6 @@
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { registerRouterInjector } from '@dojo/routing/RouterInjector';
-import TodoApp from './widgets/TodoApp';
+import App from './App';
 import { Outlet } from '@dojo/routing/Outlet';
 import { Registry } from '@dojo/widget-core/Registry';
 
@@ -9,6 +9,8 @@ import TodoList from './widgets/TodoList';
 import TodoItem from './widgets/TodoItem';
 import TodoFooter from './widgets/TodoFooter';
 import TodoFilter from './widgets/TodoFilter';
+
+require('maquette/src/maquette-polyfills');
 
 const registry = new Registry();
 
@@ -24,7 +26,7 @@ registry.define('todo-filter', Outlet(TodoFilter, 'filter', mapFilterRouteParam)
 
 const root = document.querySelector('my-app') || undefined;
 
-const Projector = ProjectorMixin(TodoApp);
+const Projector = ProjectorMixin(App);
 const projector = new Projector();
 
 const router = registerRouterInjector([{ path: '{filter}', outlet: 'filter', defaultParams: { filter: 'all' }, defaultRoute: true }], registry);


### PR DESCRIPTION
Adds required polyfills (although slight bug in that window is not passed to the polyfill correctly) and a tweak to not use classes in a Widget that has the Projector mixed in.