### PR TITLE
Remove the dojo/interfaces dep

### DIFF
--- a/custom-element-menu/package.json
+++ b/custom-element-menu/package.json
@@ -16,7 +16,6 @@
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.1.0",
     "@dojo/cli-test-intern": "~0.1.0",
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.0",
     "@dojo/test-extras": "~0.1.0",
     "@types/chai": "~3.4.0",

--- a/dojo-cli-example/package.json
+++ b/dojo-cli-example/package.json
@@ -26,6 +26,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@dojo/cli": "~0.4.2",
     "@dojo/loader": "~0.1.0",
     "@types/chai": "^3.4.34",
     "@types/chalk": "^0.4.31",

--- a/dojo-cli-example/package.json
+++ b/dojo-cli-example/package.json
@@ -26,7 +26,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.0",
     "@types/chai": "^3.4.34",
     "@types/chalk": "^0.4.31",

--- a/dojo-cli-example/src/main.ts
+++ b/dojo-cli-example/src/main.ts
@@ -1,4 +1,4 @@
-import { Command, Helper, OptionsHelper } from '@dojo/interfaces/cli';
+import { Command, Helper, OptionsHelper } from '@dojo/cli/interfaces';
 import { Argv } from 'yargs';
 import { underline } from 'chalk';
 

--- a/dojo-cli-example/tests/unit/main.ts
+++ b/dojo-cli-example/tests/unit/main.ts
@@ -2,7 +2,7 @@ const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 import command, { MyArgv } from './../../src/main';
-import { Helper } from '@dojo/interfaces/cli';
+import { Helper } from '@dojo/cli/interfaces';
 
 const testContextMessage = 'test';
 let sandbox: sinon.SinonSandbox;

--- a/todo-mvc-kitchensink/package.json
+++ b/todo-mvc-kitchensink/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.2.0",
     "@dojo/cli-test-intern": "~0.2.0",
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.0",
     "@dojo/test-extras": "^0.2.1",
     "@types/chai": "^3.4.34",

--- a/todo-mvc-tsx/package.json
+++ b/todo-mvc-tsx/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.2.0",
     "@dojo/cli-test-intern": "~0.2.0",
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.0",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.2.0",
     "@dojo/cli-test-intern": "~0.2.0",
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.0",
     "@types/chai": "^3.4.34",
     "@types/glob": "~5.0.0",

--- a/widget-showcase/package.json
+++ b/widget-showcase/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@dojo/cli-build-webpack": "~0.2.2",
     "@dojo/cli-test-intern": "~0.2.1",
-    "@dojo/interfaces": "~0.1.0",
     "@dojo/loader": "~0.1.1",
     "@dojo/test-extras": "~0.2.1",
     "@types/glob": "~5.0.0",


### PR DESCRIPTION
**Feature**

Removes the dojo/interfaces dep as per: https://github.com/dojo/meta/issues/223

TODO: migrate the necessary interfaces to the dojo/cli repo