### PR TITLE
Adding intersection-observer to README and index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The current examples are:
 - [custom-element-menu](./custom-element-menu/README.md) - Demonstrates custom element usage against standard Dojo 2 widget usage.
 - [custom-element-showcase](./custom-element-showcase/README.md) - Demonstrates using @dojo/widgets distributed as compiled custom elements.
 - [Conduit RealWorld Application](./realworld/README.md) - A realworld implementation of a medium clone, conduit.
-- [intersection-obersver](./intersection-observer/README.md) - Demonstrates using the [`Intersection`](https://github.com/dojo/widget-core#intersection) meta for creating an infinite scrolling list.
+- [intersection-observer](./intersection-observer/README.md) - Demonstrates using the [`Intersection`](https://github.com/dojo/widget-core#intersection) meta for creating an infinite scrolling list.
 
 Application examples that are deployed to [gh-pages](https://dojo.github.io/examples):
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The current examples are:
 - [custom-element-menu](./custom-element-menu/README.md) - Demonstrates custom element usage against standard Dojo 2 widget usage.
 - [custom-element-showcase](./custom-element-showcase/README.md) - Demonstrates using @dojo/widgets distributed as compiled custom elements.
 - [Conduit RealWorld Application](./realworld/README.md) - A realworld implementation of a medium clone, conduit.
+- [intersection-obersver](./intersection-observer/README.md) - Demonstrates using the [`Intersection`](https://github.com/dojo/widget-core#intersection) meta for creating an infinite scrolling list.
 
 Application examples that are deployed to [gh-pages](https://dojo.github.io/examples):
 
@@ -32,6 +33,7 @@ Application examples that are deployed to [gh-pages](https://dojo.github.io/exam
  - [Custom Element Widget Showcase](https://dojo.github.io/examples/custom-element-showcase)
  - [Custom Element Menu](https://dojo.github.io/examples/custom-element-menu)
  - [RealWorld Application](https://dojo.github.io/examples/realworld)
+ - [intersection-observer](https://dojo.github.io/examples/intersection-observer/)
 
 ## How Do I Contribute?
 
@@ -49,6 +51,7 @@ Refer to each `README.md` for details on installing and testing the examples.
 * [custom-element-showcase](./custom-element-showcase/README.md)
 * [dojo-cli-example](./dojo-cli-example/README.md)
 * [Conduit RealWorld Application](./realworld/README.md)
+* [intersection-observer](./intersection-observer/README.md)
 
 ## Licensing Information
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,8 @@
 								<p>
 									<a href="./widget-showcase/">Dojo 2 widget showcase</a><br>
 									<a href="./custom-element-showcase/">Custom elements showcase variant</a><br>
-									<a href="./custom-element-menu/">Custom elements Menu demo</a>
+									<a href="./custom-element-menu/">Custom elements Menu demo</a><br>
+									<a href="./intersection-observer/">Intersection Observer demo</a>
 								</p>
 							</div>
 							<div class="routing feature">


### PR DESCRIPTION
Adding intersection-observer links to the README page, and a link to the GH page to the `index.html`.