### PR TITLE
Pin @dojo deps for custom-element-showcase

### DIFF
--- a/custom-element-showcase/package.json
+++ b/custom-element-showcase/package.json
@@ -7,8 +7,8 @@
     "test-ci": "echo \"no tests\""
   },
   "dependencies": {
-    "@dojo/themes": "^4.0.0",
-    "@dojo/widgets": "^4.0.0",
+    "@dojo/themes": "4.0.0",
+    "@dojo/widgets": "4.0.0",
     "@webcomponents/custom-elements": "~1.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
The ce widget showcase deps need to be pinned as they reference the version in the index.html