### PR TITLE
Fix readme links. Pin dependencies in the custom element showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Here is a table of the current examples available in this repository complete wi
 | Real-world Application | [Link](./realworld) |  [Link](https://dojo.github.io/examples/realworld) | [Link](https://codesandbox.io/s/github/dojo/examples/tree/master/realworld) |  A real-world implementation of an existing site using Dojo packages: conduit.  |
 | Intersection Observer | [Link](./intersection-observer)   |  [Link](https://dojo.github.io/examples/intersection-observer/)  | [Link](https://codesandbox.io/s/github/dojo/examples/tree/master/intersection-observer) |   Demonstration of the [`Intersection`](https://github.com/dojo/widget-core#intersection) meta and how it can be used to create an infinite scrolling list. |
 | Resize Observer | [Link](./resize-observer) |  [Link](https://dojo.github.io/examples/resize-observer/)  |  | Demonstration of the [`Resize`](https://github.com/dojo/widget-core#resize) meta and how it can be used to create responsive components. |
-| Dgrid Wrapper | [Link](./dgrid-wrapper) | [Link](https://dojo.github.io.examples/dgrid-wrapper) | | Demonstration of the [`Dgrid Wrapper`](https://github.com/dojo/interop/tree/master/src/dgrid) for running [dgrid](http://dgrid.io) in a reactive way in a modern Dojo application. |
-| World Clock | [Link](./world-clock) | [Link](https://dojo.github.io.examples/world-clock) | | Demonstration of i18n in an application built using Dojo packages. |
+| Dgrid Wrapper | [Link](./dgrid-wrapper) | [Link](https://dojo.github.io/examples/dgrid-wrapper) | | Demonstration of the [`Dgrid Wrapper`](https://github.com/dojo/interop/tree/master/src/dgrid) for running [dgrid](http://dgrid.io) in a reactive way in a modern Dojo application. |
+| World Clock | [Link](./world-clock) | [Link](https://dojo.github.io/examples/world-clock) | | Demonstration of i18n in an application built using Dojo packages. |
 
 ## How Do I Contribute?
 
@@ -56,4 +56,4 @@ Refer to each `README.md` for details on installing and testing the examples:
 
 © 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 
- [Link](https://codesandbox.io/s/github/dojo/examples/tree/master/todo-mvc) | 
+ [Link](https://codesandbox.io/s/github/dojo/examples/tree/master/todo-mvc) |

--- a/custom-element-showcase/README.md
+++ b/custom-element-showcase/README.md
@@ -38,5 +38,5 @@ In order to build the project run `npm run build`.
 
 ## Licensing Information
 
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+© 2019 [OpenJS Foundation](https://openjsf.org) & contributors. [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
 

--- a/custom-element-showcase/package.json
+++ b/custom-element-showcase/package.json
@@ -7,8 +7,8 @@
     "test-ci": "echo \"no tests\""
   },
   "dependencies": {
-    "@dojo/themes": "^5.0.0",
-    "@dojo/widgets": "^5.0.0",
+    "@dojo/themes": "5.0.0",
+    "@dojo/widgets": "5.0.0",
     "@webcomponents/custom-elements": "~1.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
* Fix readme links for examples
* Pin deps in custom element showcase because the paths point to 5.0.0 in the index.html
