### PR TITLE
Fix main entry paths

### DIFF
--- a/hnpwa/package.json
+++ b/hnpwa/package.json
@@ -8,7 +8,7 @@
     "prettier": "prettier --write \"{docs,src,tests}/**/*.{ts,tsx,md}\"",
     "test-ci": "echo \"no tests\""
   },
-  "main": "src/main.ts",
+  "main": "src/main.tsx",
   "dependencies": {
     "@dojo/framework": "^6.0.0",
     "tslib": "~1.9.1"

--- a/realworld/package.json
+++ b/realworld/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "realworld-app",
 	"version": "1.0.0",
-	"main": "src/main.ts",
+	"main": "src/main.tsx",
 	"scripts": {
 		"dev": "dojo build -m dev -s -w memory",
 		"build": "dojo build",
-    "build:ghpages": "dojo build --dojorc .dojorc-ghpages",
+		"build:ghpages": "dojo build --dojorc .dojorc-ghpages",
 		"prettier": "prettier --write \"{docs,src,tests}/**/*.{ts,tsx,md}\"",
 		"test": "dojo build -m unit && dojo test",
 		"test-ci": "dojo build -m unit && dojo test -c \"browserstack\" --usr dylanschiemann2 -k 4Q2g8YAc9qeZzB2hECnS"

--- a/todo-mvc-kitchensink/package.json
+++ b/todo-mvc-kitchensink/package.json
@@ -2,10 +2,10 @@
 	"name": "dojo2-todo-mvc-kitchensink",
 	"version": "0.0.1",
 	"description": "TodoMVC using Dojo",
-	"main": "src/main.ts",
+	"main": "src/main.tsx",
 	"scripts": {
 		"build": "dojo build",
-    "build:ghpages": "dojo build --dojorc .dojorc-ghpages",
+		"build:ghpages": "dojo build --dojorc .dojorc-ghpages",
 		"prettier": "prettier --write \"{docs,src,tests}/**/*.{ts,tsx,md}\"",
 		"build:tests": "dojo build -m unit && dojo build -m functional",
 		"test": "dojo build --dojorc .dojorc-test && npm run build:tests && dojo test -a -c local",

--- a/todo-mvc/index.js
+++ b/todo-mvc/index.js
@@ -1,0 +1,2 @@
+require('ts-node').register(); // This will register the TypeScript compiler
+require('./src/electron');

--- a/todo-mvc/package.json
+++ b/todo-mvc/package.json
@@ -2,7 +2,7 @@
   "name": "dojo-todo-mvc",
   "version": "0.0.1",
   "description": "TodoMVC using Dojo",
-  "main": "src/main.ts",
+  "main": "src/main.tsx",
   "scripts": {
     "build": "dojo build",
     "build:ghpages": "dojo build --dojorc .dojorc-ghpages",

--- a/todo-mvc/src/electron.ts
+++ b/todo-mvc/src/electron.ts
@@ -1,0 +1,52 @@
+import { app, BrowserWindow } from "electron";
+import * as path from "path";
+import pkgDir from 'pkg-dir';
+
+let mainWindow: Electron.BrowserWindow | null;
+
+function createWindow() {
+	// Create the browser window.
+	mainWindow = new BrowserWindow({
+		height: 600,
+		width: 800,
+	});
+
+	// and load the index.html of the app.
+	mainWindow.loadFile(path.join(pkgDir.sync()!, "output", "dev", "index.html"));
+
+	// Open the DevTools.
+	mainWindow.webContents.openDevTools();
+
+	// Emitted when the window is closed.
+	mainWindow.on("closed", () => {
+		// Dereference the window object, usually you would store windows
+		// in an array if your app supports multi windows, this is the time
+		// when you should delete the corresponding element.
+		mainWindow = null;
+	});
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on("ready", createWindow);
+
+// Quit when all windows are closed.
+app.on("window-all-closed", () => {
+	// On OS X it is common for applications and their menu bar
+	// to stay active until the user quits explicitly with Cmd + Q
+	if (process.platform !== "darwin") {
+		app.quit();
+	}
+});
+
+app.on("activate", () => {
+	// On OS X it"s common to re-create a window in the app when the
+	// dock icon is clicked and there are no other windows open.
+	if (mainWindow === null) {
+		createWindow();
+	}
+});
+
+// In this file you can include the rest of your app"s specific main process
+// code. You can also put them in separate files and require them here.


### PR DESCRIPTION
Looks like codesandbox now resolves this properly which makes our projects fail on codesandbox as should be pointing to the `.tsx` versions.